### PR TITLE
background field subtraction

### DIFF
--- a/dataflow/modules/refl.py
+++ b/dataflow/modules/refl.py
@@ -8,6 +8,7 @@ from reflred.refldata import ReflData
 from reflred.polarization import PolarizationData
 from reflred.deadtime import DeadTimeData
 from reflred.footprint import FootprintData
+from reflred.backgroundfield import BackgroundFieldData
 
 INSTRUMENT = "ncnr.refl"
 
@@ -120,6 +121,7 @@ def define_instrument():
     deadtime = df.DataType(INSTRUMENT+".deadtime", DeadTimeData)
     footprint = df.DataType(INSTRUMENT+".footprint.params", FootprintData)
     flux = df.DataType(INSTRUMENT+".flux.params", FluxData)
+    backgroundfield = df.DataType(INSTRUMENT + ".backgroundfield.params", BackgroundFieldData)
 
     #import json
     #import os
@@ -135,7 +137,7 @@ def define_instrument():
         id=INSTRUMENT,
         name='NCNR reflectometer',
         menu=[('steps', modules)],
-        datatypes=[refldata, poldata, deadtime, footprint, flux],
+        datatypes=[refldata, poldata, deadtime, footprint, flux, backgroundfield],
         template_defs=templates.get_templates(INSTRUMENT),
         )
 

--- a/reflred/backgroundfield.py
+++ b/reflred/backgroundfield.py
@@ -1,0 +1,256 @@
+r"""
+Background field subtraction
+"""
+from __future__ import division
+
+import numpy as np
+import scipy.optimize as so
+import matplotlib.pyplot as plt
+from copy import copy
+
+#from dataflow.lib.uncertainty import Uncertainty as U, interp
+#from .refldata import ReflData
+
+# BackgroundFieldData class returns results of background field fitting
+
+class BackgroundFieldData(object):
+    def __init__(self, p, dp2, s, ds2, dsp, chisq):
+        self.p = p
+        self.dp2 = dp2
+        self.s = s
+        self.ds2 = ds2
+        self.dsp = dsp
+        self.chisq = chisq
+    def get_metadata(self):
+        return {
+            "epsD": self.p,
+            "epsD_var": self.dp2,
+            "scale": self.s,
+            "scale_var": self.ds2,
+            "scale_epsD_covar": self.dsp,
+            "fit_chi-squared": self.chisq
+        }
+    def get_plottable(self):
+        return self.get_metadata()
+
+
+def background_reservoir(ai, epsD, af, epssi, Fd, scale):
+    """
+    Calculates background from a reservoir surrounded by Si
+    """
+    A = np.exp(-epsD * (1. / np.sin(ai) + 1. / np.sin(af)))
+
+    res = (1 - A) / (1. + np.sin(ai) / np.sin(af))
+
+    si = epssi * (Fd * np.sin(af) / np.sin(ai + af)) * (0.5 + 0.5 * A)
+
+    # first term is the background value; the second contains intermediates used
+    # in the Jacobian function and error calculation
+    return scale*(res+si), (A, res, si)
+
+def background_reservoir_jac(ai, epsD, af, epssi, Fd, scale):
+    """
+    Calculates Jacobian function for background_reservoir with
+    parameters (scale, epsD)
+    """
+    A, res, si = background_reservoir(ai, epsD, af, epssi, Fd, scale)[1]
+    dA_depsD = -(1. / np.sin(ai) + 1. / np.sin(af)) * A
+    dres_depsD = -dA_depsD / (1. + np.sin(ai) / np.sin(af))
+    dsi_depsD = epssi * (Fd * np.sin(af) / np.sin(ai + af)) * (0.5 * dA_depsD)
+
+    J = np.array([res + si, scale*(dres_depsD + dsi_depsD)])
+
+    return J
+
+def background_reservoir_error(ai, epsD, af, epssi, Fd, scale, pcov):
+    """
+    Uses covariance matrix of fit result to propagate uncertainty
+    """
+    J = background_reservoir_jac(ai, epsD, af, epssi, Fd, scale)
+
+    df = list()
+    for j in J.T:
+        df.append(np.sqrt(j.T.dot(pcov.dot(j))))
+
+    return np.array(df)
+
+def fractional_solid_angle(s4, LS4, L4D, HD):
+    """
+    Calculates fractional solid angle subtended by a detector
+    of height HD located a distance LS4 from the sample, fronted
+    by a collimating slit a distance L4D away with width s4. Only
+    works if the result is << 1.
+    """
+
+    dvert = np.arctan( HD / (LS4 + L4D) )
+    dhorz = np.arctan( s4 / LS4 )
+    return dvert * dhorz / (4 * np.pi)
+
+def detector_footprint(af, s3, s4, LS3, L34):
+    """
+    Calculates effective footprint on sample viewed by the detector,
+    based on post-sample slit values and the angle between the sample
+    and the detector.
+    """
+
+    return s3 * LS3 / (L34 * np.sin(af)) * (s4 / s3 + 1. + L34 / LS3)
+
+def fit_background_field(back, epsD0, epssi, fit_scale, scale_value=1.0, LS3=380, LS4=1269, LSD=1675, HD=150, Qcutoff=0.05, maxF=75):
+    """
+    Performs the fit to the background field.
+    """
+
+    ##type: (ReflData) -> (np.ndarray)
+    #TODO: Better error handling if slit 4 doesn't exist (currently hardcoded detector size)
+    #TODO: Include residuals for inspection (can currently pass both through a subtract module)
+
+    # Initialize variables
+    ai = list()
+    af = list()
+    s3 = list()
+    s4 = list()
+    v = list()
+    dv = list()
+    Qz_target = list()
+
+    # Check for slit distances, otherwise use values from data file
+    LS3 = back[0].slit3.distance if not np.isinf(back[0].slit3.distance) else LS3
+    LS4 = back[0].slit4.distance if not np.isinf(back[0].slit4.distance) else LS4
+    L4D = LSD - LS4
+
+    # Extract relevant quantities from inputs
+    for b in back:
+
+        ai.append(b.sample.angle_x)
+        Qz_target.append(b.Qz_target if not np.all(np.isnan(b.Qz_target)) else 4*np.pi/b.detector.wavelength*np.sin(np.radians(b.sample.angle_x)))
+        af.append(b.detector.angle_x - b.sample.angle_x)
+        s3.append(b.slit3.x)
+        s4.append(b.slit4.x if not np.all(np.isinf(b.slit4.x)) else 25. * np.ones(b.v.shape))
+        v.append(b.v)
+        dv.append(b.dv)
+
+    # Concatenate and filter results based on the Qcutoff parameter
+    Qz_target = np.concatenate(Qz_target)
+    ai = np.radians(np.concatenate(ai))
+    af = np.radians(np.concatenate(af))
+    crit = (Qz_target > Qcutoff) & (af > 0.)
+    ai = ai[crit]
+    af = af[crit]
+    s3 = np.concatenate(s3)[crit]
+    s4 = np.concatenate(s4)[crit]
+    v = np.concatenate(v)[crit]
+    dv = np.concatenate(dv)[crit]
+
+    # Calculate the detector footprints and use maximum value relative to sample size maxF
+    Fd = detector_footprint(af,
+                            s3,
+                            s4,
+                            LS3,
+                            LS4 - LS3)
+
+    Fd = np.min((Fd, maxF*np.ones(Fd.shape)), axis=0)
+
+    # Calculate the detector solid angle
+    SA = fractional_solid_angle(s4, LS4, L4D, HD)
+
+    # Define fit function and Jacobian
+    def minfunc(pars):
+
+        scale, epsD = pars
+        return (background_reservoir(ai,
+                                    epsD,
+                                    af,
+                                    epssi,
+                                    Fd,
+                                    scale)[0] * SA - v)/dv
+
+    def jacfunc(pars):
+
+        scale, epsD = pars
+        return (background_reservoir_jac(ai, epsD, af, epssi, Fd, scale)*np.tile(SA/dv, (len(pars), 1))).T
+
+    # Condition the fit if the scale factor is not included in the fit, then perform the fit
+    if not fit_scale:
+        pout, pcov = so.leastsq(lambda epsD: minfunc([scale_value, epsD]), epsD0, Dfun=lambda epsD: jacfunc([1.0, epsD])[:,1], full_output=True, ftol=1e-15,
+                                xtol=1e-15)[:2]
+        lenpout = len(pout)
+        pout = np.array([scale_value, pout])
+        pcov = np.array([[0.0, 0.0],[0.0, pcov[0]]])
+    else:
+        pout, pcov = so.leastsq(minfunc, np.array([scale_value, epsD0]), Dfun=jacfunc, full_output=True, ftol=1e-15, xtol=1e-15)[:2]
+        lenpout = len(pout)
+
+    # Calculate fitting error (not used) and chi-squared (only reported)
+    perr, chisq = np.sqrt(np.diag(pcov)), np.sqrt(np.sum(minfunc(pout)**2) / (len(v) - lenpout))
+
+    # for testing purposes only
+    if 0:
+        plt.errorbar(np.arange(len(v)), v, dv, fmt='o')
+        plt.plot(np.arange(len(v)), background_reservoir(ai, pout[1], af, epssi, Fd, pout[0])[0] * SA)
+        plt.show()
+
+    # Create fit data structure
+    bff = BackgroundFieldData(pout[1], pcov[1,1], pout[0], pcov[0,0], pcov[0,1], chisq)
+    bff.epssi = epssi
+    bff.LS3 = LS3
+    bff.LS4 = LS4
+    bff.L4D = L4D
+    bff.HD = HD
+    bff.maxF = maxF
+
+    # Create calculated background data for comparison to input background data
+    back2 = [copy(b) for b in back]
+
+    for i, b in enumerate(back2):
+        ai2 = np.radians(b.sample.angle_x)
+        af2 = np.radians(b.detector.angle_x - b.sample.angle_x)
+        s32 = b.slit3.x
+        s42 = b.slit4.x if not np.all(np.isinf(b.slit4.x)) else 25. * np.ones(b.v.shape)
+
+        # Uncomment following lines if output data should only include the data above Qcutoff
+        # Currently all data are calculated
+
+        #Qz_target = b.Qz_target if not np.all(np.isnan(b.Qz_target)) else 4 * np.pi / b.detector.wavelength * np.sin(
+        #        np.radians(b.sample.angle_x))
+        #crit = (Qz_target > Qcutoff) & (af > 0.)
+        #ai2 = ai2[crit]
+        #af2 = af2[crit]
+        #s32 = s32[crit]
+        #s42 = s42[crit]
+
+        Fd2 = detector_footprint(af2, s32, s42, LS3, LS4 - LS3)
+        Fd2 = np.min((Fd2, maxF * np.ones(Fd2.shape)), axis=0)
+        SA2 = fractional_solid_angle(s42, LS4, L4D, HD)
+
+        bestfit = background_reservoir(ai2, pout[1], af2, epssi, Fd2, pout[0])[0]
+        bestfiterr = background_reservoir_error(ai2, pout[1], af2, epssi, Fd2, pout[0], pcov)
+
+        back2[i].v = bestfit * SA2
+        back2[i].dv = bestfiterr * SA2
+
+    return bff, back2
+
+def apply_background_field_subtraction(data, epsD, epssi, LS3, LS4, L4D, HD, maxF, scale, pcov):
+    """
+    Applies background field subtraction to specular data
+    """
+    for (i,d) in enumerate(data):
+        I, varI = subtract_background_field(d, epsD, epssi, LS3, LS4, L4D, HD, maxF, scale, pcov)
+        data[i].v, data[i].dv = I, np.sqrt(varI)
+
+def subtract_background_field(d, epsD, epssi, LS3, LS4, L4D, HD, maxF, scale, pcov):
+    """
+    Subtracts background field from a single specular data set with error propagation
+    """
+    # TODO: Better error handling if slit 4 doesn't exist (currently hardcoded detector size)
+    ai = np.radians(d.sample.angle_x)
+    af = np.radians(d.detector.angle_x - d.sample.angle_x)
+    s4 = d.slit4.x if not np.all(np.isinf(d.slit4.x)) else 25. * np.ones(d.v.shape)
+    Fd = detector_footprint(af, d.slit3.x, s4, LS3, LS4 - LS3)
+    Fd = np.min((Fd, maxF * np.ones(Fd.shape)), axis=0)
+    SA = fractional_solid_angle(s4, LS4, L4D, HD)
+
+    bkg = background_reservoir(ai, epsD, af, epssi, Fd, scale)[0]*SA
+    bkg_err = background_reservoir_error(ai, epsD, af, epssi, Fd, scale, pcov)*SA
+
+    return d.v - bkg, d.dv**2 + bkg_err**2

--- a/reflred/joindata.py
+++ b/reflred/joindata.py
@@ -201,6 +201,8 @@ def build_dataset(group, columns):
     data.detector.angle_x = columns['Td']
     data.slit1.x = columns['s1']
     data.slit2.x = columns['s2']
+    data.slit3.x = columns['s3']
+    data.slit4.x = columns['s4']
     data.detector.wavelength = columns['L']
     data.detector.wavelength_resolution = columns['dL']
     data.monitor.count_time = columns['time']
@@ -233,6 +235,8 @@ def get_fields(group):
     columns = dict(
         s1=[data.slit1.x for data in group],
         s2=[data.slit2.x for data in group],
+        s3=[data.slit3.x for data in group],
+        s4=[data.slit4.x for data in group],
         dT=[data.angular_resolution for data in group],
         Ti=[data.sample.angle_x for data in group],
         Td=[data.detector.angle_x for data in group],

--- a/reflred/steps.py
+++ b/reflred/steps.py
@@ -871,6 +871,132 @@ def subtract_background(data, backp, backm, align="none"):
     apply_background_subtraction(data, backp, backm)
     return data
 
+@module
+def fit_background_field(back, fit_scale=True, scale=1.0, epsD0=0.01, epssi=2.857e-4, LS3=380, LS4=1269, LSD=1675, HD=150, maxF=75, Qcutoff=0.05):
+    """
+    Fit the background field from a thin liquid reservoir to background
+    datasets. Background datasets:
+
+     o Can be any at any (non-specular) condition
+
+     o Should already be normalized by incident intensity
+
+     o Can involve any number of scans
+
+    The background datasets are fit using a Levenberg-Marquardt algorithm to a model
+    involving a two parameters: epsD, the product of the incoherent attenuation coefficient
+    of the reservoir (eps) and the reservoir thickness D, and a scale factor that accounts for
+    uncertainty in the instrument geometry, i.e. the post-sample slit distances and/or the
+    solid angle subtended by the detector.
+
+    The uncertainty in the optimized parameters are estimated from the covariance matrix,
+    and the chi-squared value of the fit (typically 1.5 or less) is also calculated and available
+    in the parameter output. Note that the covariance matrix itself is passed to subract_background_field
+    because the parameters are correlated.
+
+    If the scale factor is not included in the fit, the accuracy of the calculation depends critically on
+    correct values for the instrument geometry. The geometry is inferred from the data files;
+    if it is missing, certain values can be overridden using the data entry boxes. These include the
+    slit4-detector distance (0 for instruments with no slit4) and the detector height (for horizontal
+    reflectometers, the width).
+
+    The calculation assumes a geometry like that of the NIST liquid flow cell, in which the liquid reservoir
+    is encased in silicon. For a different cell material (e.g. sapphire), the appropriate incoherent
+    extinction coefficient for the material should replace the default Si value.
+
+    **Inputs**
+
+    back (refldata[]) : group of background datasets
+
+    epsD0 {Reservoir extinction coefficient guess (mm^-1)} (float:mm^-1) : initial guess
+    for product of incoherent extinction coefficient of reservoir and reservoir thickness
+
+    epssi {Extinction coefficient of Si (mm^-1)} (float:mm^-1) : incoherent
+    extinction coefficient of Si or cell materials
+
+    fit_scale {Include scale factor in fit?} (bool) : True if scale factor on detector solid angle
+    should be included in fit (use if uncertain of the instrument geometry)
+
+    scale {Scale factor value} (float) : Value of scale factor. Initial guess if scale
+    factor is included in fit; otherwise fixed scale factor value.
+
+    Qcutoff {Target Qz cutoff (Ang^-1)} (float:Ang^-1) : Cutoff target Q_z value below which background data
+    are excluded from background fit
+
+    LS3 {sample-slit3 distance (mm)} (float:mm) : Distance from sample to slit3
+
+    LS4 {sample-slit4 distance (mm)} (float:mm) : Distance from sample to slit4
+
+    LSD {sample-detector distance (mm)} (float:mm) : Distance from sample to detector
+
+    HD {detector height (mm)} (float:mm) : Height of detector
+
+    maxF {maximum beam footprint (mm)} (float:mm) : Sample dimension in beam direction
+
+    **Returns**
+
+    fitparams (ncnr.refl.backgroundfield.params) : fit parameters, covariances, and chi-squared
+
+    fit (refldata[]) : ReflData structure containing fit outputs (for plotting against
+    background inputs to inspect background field fit)
+
+    2018-06-12 David P. Hoogerheide; last updated 2018-10-12
+    """
+
+    from .backgroundfield import fit_background_field
+
+    bff, outfitdata = fit_background_field(back, epsD0, epssi, fit_scale, scale, LS3, LS4, LSD, HD, Qcutoff, maxF)
+
+    return bff, outfitdata
+
+
+@module
+def subtract_background_field(data, bfparams, epsD=None, epsD_var=None, scale=None, scale_var=None, scale_epsD_covar=None):
+    """
+    Subtract the background field from a thin liquid reservoir from
+    a specular dataset, which should already be normalized by the incident intensity.
+    Applies the background field fit with the "Fit Background Field" module. See that
+    module's description for more details.
+
+    **Inputs**
+
+    data (refldata[]) : specular data
+
+    bfparams (ncnr.refl.backgroundfield.params) : background field parameters
+
+    epsD {epsD} (float) : p
+
+    epsD_var {epsD variance} (float) : dp2
+
+    scale {scale} (float) : s
+
+    scale_var {scale factor variance} : ds2
+
+    scale_epsD_covar {covariance of scale factor and epsD} : dsp
+
+    **Returns**
+
+    output (refldata[]) : background subtracted specular data
+
+    2018-06-12 David P. Hoogerheide; last updated 2018-10-12
+    """
+
+    from .backgroundfield import apply_background_field_subtraction
+
+    data = [copy(d) for d in data]
+
+    if epsD is None: epsD = bfparams.p
+    if epsD_var is None: epsD_var = bfparams.dp2
+    if scale is None: scale = bfparams.s
+    if scale_var is None: scale_var = bfparams.ds2
+    if scale_epsD_covar is None: scale_epsD_covar = bfparams.dsp
+
+    pcov = np.array([[scale_var, scale_epsD_covar],
+                     [scale_epsD_covar, epsD_var]])
+
+    apply_background_field_subtraction(data, epsD, bfparams.epssi, bfparams.LS3, bfparams.LS4, bfparams.L4D, bfparams.HD, bfparams.maxF, scale, pcov)
+
+    return data
 
 @module
 def divide_intensity(data, base):


### PR DESCRIPTION
Contains new modules to enable background field subtraction for liquid cell reflectometry. Relevant changes are in steps.py, joindata.py, refl.py, and backgroundfield.py. Changes in fetch.py, default_config.py, and setup.py can be ignored.