### PR TITLE
cross-talk between different reductions when template parameters are specified

### DIFF
--- a/dataflow/calc.py
+++ b/dataflow/calc.py
@@ -330,7 +330,7 @@ def fingerprint_node(module, node_config, inputs_fp):
     """
     Create a unique sha1 hash for a module based on its attributes and inputs.
     """
-    config = module.get('config', {})
+    config = module.get('config', {}).copy()
     config.update(node_config)
     config_str = str(_format_ordered(config))
     current_module_version = lookup_module(module['module']).version


### PR DESCRIPTION
Due to an update bug in template fingerprinting, the configuration options for a node that are set in one template will modify the default configuration options for that module in all subsequent templates running in the same python process.

For example, setting a sample width of 5 in one reduction loader will cause **all subsequent reductions** to inherit the value of 5 for sample width if they do not explicitly set the value.  The result will be a somewhat unpredictable value of ΔQ since this can act as a virtual slit in the measurement.  All other values left as the default in any module in the template will be similarly affected.  Maybe points are randomly masked off in some reductions?  Maybe some have deadtime correction on and others have it off?

This bug will appear if we are reusing python processes on the server for many requests, such as in a process pool, with the result of the reduction depending on which pool member processed the request.