### PR TITLE
Export regression

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,5 @@ __pycache__
 /reflred/src/_rebin.cc
 /reflred.egg-info/
 /reflweb/config.py
-/reflweb/git_version_*
+/reflweb/git_version*
+/dataflow/git_version*

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,3 @@
 recursive-include dataflow *.json
 recursive-include reflweb/static *.js *.html *.css
-include reflweb/git_version_*
+include dataflow/git_revision

--- a/dataflow/fakeredis.py
+++ b/dataflow/fakeredis.py
@@ -138,6 +138,9 @@ class FileBasedCache(object):
             lookups = filenums[low:(high+1 if high != -1 else None)]
             return [open(os.path.join(keydir, str(n)), "rb").read() for n in lookups]
 
+    def __repr__(self):
+        return "<%s.%s %s>" % (
+            self.__class__.__module__, self.__class__.__name__, self.cachedir)
 
 
 def demo():

--- a/dataflow/rev.py
+++ b/dataflow/rev.py
@@ -29,11 +29,12 @@ The simplest way to create git_revision is to run rev from setup.py::
 
     ...
 
-    # Include the git revision in the package data.
-    package_data = {package: ['git_revision']}
+    # Include git revision in the package data.  This can be done by adding
+    # it to setup() or having "include dataflow/git_revision" in MANIFEST.in.
+    #package_data = {package: ['git_revision']}
     setup(
         ...
-        package_data=package_data,
+        #package_data=package_data,
         include_package_data=True,
         ...
     )

--- a/dataflow/rev.py
+++ b/dataflow/rev.py
@@ -1,0 +1,225 @@
+"""
+Commit id and timestamp from the git repo.
+
+Drop the file rev.py into a top level directory of your package, right
+below the root of the repository.  From within your application you can
+then do::
+
+    from . import rev
+
+    rev.print_revision()  # print the repo version
+    commit, timestamp = rev.revision_info()  # return commit and timestamp
+
+If you use a more complicated source tree then you will need to replace
+repo_path() with a function that returns the path to the repo root before
+requesting the revision information.
+
+On pip install the repo root directory may not be available.  In this
+case you need to create package/git_revision that gets installed into
+site-pacakges along with your other sources.
+
+The simplest way to create git_revision is to run rev from setup.py::
+
+    import sys
+    import os
+
+    # Create the resource file git_revision.
+    package = 'dataflow'
+    os.system(f'"{sys.executable}" {package}/rev.py')
+
+    ...
+
+    # Include the git revision in the package data.
+    package_data = {package: ['git_revision']}
+    setup(
+        ...
+        package_data=package_data,
+        include_package_data=True,
+        ...
+    )
+
+You should add the following to .gitignore, substituting your package name::
+
+    /dataflow/git_revision
+
+**Notes**
+
+If your package doesn't do a lot when you first import it, then you
+can access the methods from rev directly from setup.py instead of running
+it as a separate command::
+
+    # Add the directory containing your package root to the path
+    import sys
+    from os.path import abspath, dirname
+    sys.path.insert(0, abspath(dirname(__file__)))
+
+    from dataflow import rev
+    rev.store_rev()
+    package_data = {'dataflow': [rev.RESOURCE_NAME]}
+
+    ...
+
+Even fancier, you can load rev as a module without loading your package. This
+requires loading the module from a path on the filesystem, which is rather
+tedious::
+
+    from os.path import abspath, dirname, join as joinpath
+    import importlib.util
+
+    # Load dataflow/rev.py as a toplevel module rev (python 3.5+).
+    package = 'dataflow'
+    rev_path = joinpath(abspath(dirname(__file__)), package, 'rev.py')
+    rev_spec = importlib.util.spec_from_file_location('rev', rev_path)
+    rev = importlib.util.module_from_spec(rev_spec)
+    sys.modules['rev'] = rev
+    rev_spec.loader.exec_module(rev)
+
+    # Build the resource file dataflow/git_revision
+    rev.store_rev()
+    package_data = {package: [rev.RESOURCE_NAME]}
+
+    ...
+
+"""
+import os.path
+
+def repo_path():
+    """Return path to the git repo for the project"""
+    return os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+
+def print_revision():
+    """Print the git revision and timestamp"""
+    revision, timestamp = revision_info()
+    print("git revision", revision, timestamp)
+
+def store_revision():
+    """
+    Call from setup.py to save the git revision to the distribution.
+
+    See :mod:`rev` for details.
+    """
+    commit, timestamp = git_rev(repo_path())
+    path = os.path.abspath(os.path.join(os.path.dirname(__file__), RESOURCE_NAME))
+    with open(path, 'w') as fd:
+        fd.write(f"{commit} {timestamp}\n")
+
+
+RESOURCE_NAME = 'git_revision'
+_REVISION_INFO = () # cached value of git revision
+def revision_info():
+    """
+    Get the git hash and mtime of the repository, or the installed files.
+    """
+    # TODO: test with "pip install -e ." for developer mode
+    global _REVISION_INFO
+
+    if not _REVISION_INFO:
+        _REVISION_INFO = git_rev(repo_path())
+
+    if not _REVISION_INFO:
+        try:
+            from importlib import resources
+        except ImportError: # CRUFT: pre-3.7 requires importlib_resources
+            import importlib_resources as resources
+        revdata = resources.read_text(__name__, RESOURCE_NAME)
+        commit, timestamp = revdata.strip().split()
+        _REVISION_INFO = commit, int(timestamp)
+
+    if not _REVISION_INFO:
+        _REVISION_INFO = "unknown", 0
+
+    return _REVISION_INFO
+
+def git_rev(repo):
+    """
+    Get the git revision for the repo in the path *repo*.
+
+    Returns the commit id of the current head as well as the committer
+    timestamp as integer seconds since Jan 1 1970.
+
+    Note: this function parses the files in the git repository directory
+    without using the git application.  It may break if the structure of
+    the git repository changes.  It only reads files, so it should not do
+    any damage to the repository in the process.
+    """
+    # Based on stackoverflow am9417 and Ciro Santilli 新疆改造中心法轮功六四事件
+    # https://stackoverflow.com/questions/14989858/get-the-current-git-hash-in-a-python-script/59950703#59950703
+    # https://stackoverflow.com/questions/22968856/what-is-the-file-format-of-a-git-commit-object-data-structure/37438460#37438460
+
+    git_root = os.path.join(repo, ".git")
+    git_head = os.path.join(git_root, "HEAD")
+    if not os.path.exists(git_head):
+        return None
+
+    # Read .git/HEAD file
+    with open(git_head, 'r') as fd:
+        head_ref = fd.read()
+
+    # Find head file .git/HEAD (e.g. ref: ref/heads/master => .git/ref/heads/master)
+    if not head_ref.startswith('ref: '):
+        raise RuntimeError("expected 'ref: path/to/head' in %s"%git_head)
+    head_ref = head_ref[5:].strip()
+    head_ref = os.path.join(git_root, *head_ref.split('/'))
+
+    # Read commit id from head file
+    with open(head_ref, 'r') as fd:
+        commit = fd.read().strip()
+
+    # Get timestamp from commit file .git/objects/ff/fffffffffffff
+    # This is a zlib compressed file with contents:
+    #
+    #     commit {size}\0tree {tree_id}
+    #     parent {parent_id}
+    #     ...
+    #     parent {parent_id}
+    #     author {author info} {timestamp} {timezone}
+    #     committer {committer info} {timestamp} {timezone}
+    #
+    #     {commit message lines}
+    #
+    import zlib
+    commit_ref = os.path.join(git_root, "objects", commit[:2], commit[2:])
+    with open(commit_ref, 'rb') as fd:
+        data = zlib.decompress(fd.read())
+    committer = next(v for v in data.split(b'\n') if v.startswith(b'committer'))
+    timestamp = int(committer.strip().rsplit(maxsplit=2)[-2])
+
+    return commit, timestamp
+
+# CRUFT: unused
+def git_rev_cmd(repo):
+    """
+    Get the git revision for the repo in the path *repo*.
+
+    Returns the commit id of the current head as well as the committer
+    timestamp as integer seconds since Jan 1 1970.
+
+    Note: this function requires the git command on the system path.
+    """
+    import subprocess
+
+    # for local and development installs of the server, the .git folder
+    # will exist in parent (reduction) folder...
+    git_root = os.path.join(repo, ".git")
+    if not os.path.exists(git_root):
+        return None
+
+    revision = subprocess.Popen(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repo, stdout=subprocess.PIPE
+        ).stdout.read().strip().decode('ascii')
+    timestamp = subprocess.Popen(
+        ["git", "log", "-1", "--pretty=format:%ct"],
+        cwd=repo, stdout=subprocess.PIPE
+        ).stdout.read().strip().decode('ascii')
+    return revision, int(timestamp)
+
+def main():
+    """
+    When run as a python script create git_revision in the current directory.
+    """
+    print_revision()
+    store_revision()
+
+if __name__ == "__main__":
+    main()

--- a/reflweb/server_flask.py
+++ b/reflweb/server_flask.py
@@ -66,6 +66,9 @@ for method in api.api_methods:
     app.add_url_rule(path, path, wrapped, methods=["POST"])
     app.add_url_rule(shortpath, shortpath, wrapped, methods=["POST"])
 
+from dataflow.rev import print_revision
+print_revision()
+
 if __name__ == '__main__':
     logging.basicConfig(level=logging.WARNING)
     port = 8002

--- a/regression.py
+++ b/regression.py
@@ -27,10 +27,11 @@ import importlib
 import difflib
 import traceback
 
-from dataflow.cache import set_test_cache
-from dataflow.core import Template, lookup_module
-from dataflow.calc import process_template
 from dataflow import fetch
+from dataflow.cache import set_test_cache
+from dataflow.core import Template, lookup_instrument, lookup_module
+from dataflow.calc import process_template
+from dataflow.rev import revision_info
 
 try:
     from reflweb import config
@@ -52,32 +53,110 @@ else:
 # - open brace of template
 TEMPLATE = re.compile(r"^(#|//) *([\"']?template(_data)?[\"']?)? *[:=]? *\{")
 
+def prepare_dataflow(template_def):
+    # Set up caching if not already done.
+    fetch.DATA_SOURCES = config.data_sources
+    set_test_cache()
 
-LOADED_INSTRUMENTS = set()
+    # Find the instrument name from the first module and register it.
+    first_module = template_def['modules'][0]['module']
+    instrument_id = first_module.split('.')[1]
+    load_instrument(instrument_id)
+
 def load_instrument(instrument_id):
     # type: (str) -> None
     """
     Load the dataflow instrument definition given the instrument name.
     """
-    if instrument_id not in LOADED_INSTRUMENTS:
-        instrument_module_name = 'dataflow.modules.'+instrument_id
-        instrument_module = importlib.import_module(instrument_module_name)
+    instrument_module_name = 'dataflow.modules.'+instrument_id
+    instrument_module = importlib.import_module(instrument_module_name)
+    try:
+        return lookup_instrument(instrument_module.INSTRUMENT)
+    except KeyError:
         instrument_module.define_instrument()
-        LOADED_INSTRUMENTS.add(instrument_id)
+    return lookup_instrument(instrument_module.INSTRUMENT)
 
+def run_template(template_data, concatenate=True):
+    """
+    Run a template defined by *template_data*.
 
-def show_diff(old, new, show_diff=True):
+    Returns *export* = {'datatype': str, 'values': [content, ...]}.
+
+    Each *content* block is {'filename': str, 'value': *value*}, where
+    value depends on the export type requested in *template_data*.
+
+    Output from "column" export will contain a string with the file content,
+    with the first line containing the template data structure.
+
+    Output from "hdf" export will contain a sequence of bytes defining the
+    HDF file, with template data stored in the attribute NXroot@template_def.
+
+    If *concatenate* then all datasets will be combined into a single value.
+
+    Example::
+
+        from dataflow.rev import revision_info
+        revision, timestamp = revision_info()
+        template_data = {
+            "template": json.loads(template_str),
+            "config": {}, # optional?
+            "node": node_id,
+            "terminal": terminal_id,
+            "export_type": "column",
+            "server_git_hash": revision,
+            "server_mtime": timestamp,
+            "datasources": [
+                # ignored...
+                {'url': '...', 'start_path': '...', 'name': '...'},
+                ],
+        }
+        export = run_template(template_data, concatenate=False)
+        for entry in export['values']:
+            with open(entry['filename'], 'w') as fd:
+                fd.write(entry['value'])
+    """
+    #print("template_data", template_data['datasources'])
+    template_def = template_data['template']
+    template_config = template_data.get('config', {})
+    target = template_data['node'], template_data['terminal']
+    # CRUFT: use template_data["export_type"] when regression files are updated
+    export_type = template_data.get('export_type', 'column')
+    template = Template(**template_def)
+    #template.show()  # for debugging, show the template structure
+
+    # run the template
+    # TODO: use datasources given in template? It may be a security risk...
+    #datasources = template_data.get('datasources', [])
+    #if datasources:
+    #    original = fetch.DATA_SOURCES
+    #    fetch.DATA_SOURCES = datasources
+    #    try:
+    #        retval = process_template(template, template_config, target=target)
+    #    finally:
+    #        fetch.DATA_SOURCES = original
+    #else:
+    retval = process_template(template, template_config, target=target)
+
+    export = retval.get_export(
+        headers=template_data,
+        concatenate=concatenate,
+        export_type=export_type)
+    return export
+
+def compare(old, new, show_diff=True, skip=0):
     # type: (str, str) -> bool
     """
     Compare *old* and *new* text, returning True if they differ.
 
+    *old* and *new* are multi-line strings.
+
     *show_diff* is True if the differences should be printed to stdout.
 
-    The text should be a multi-line string.
+    *skip* is the number of lines to skip before starting the comparison.
     """
     has_diff = False
-    delta = difflib.unified_diff(old.splitlines(True),
-                                 new.splitlines(True),
+    delta = difflib.unified_diff(old.splitlines(True)[skip:],
+                                 new.splitlines(True)[skip:],
                                  fromfile="old", tofile="new")
     for line in delta:
         if show_diff:
@@ -85,7 +164,6 @@ def show_diff(old, new, show_diff=True):
         has_diff = True
 
     return has_diff
-
 
 def replay_file(filename):
     # type: (str) -> None
@@ -98,60 +176,32 @@ def replay_file(filename):
     Raises *RuntimeError* if the files differ.
     """
 
-    # Here's how the export file is constructed by the reductus client.
-    # This snippet is from reflweb/static/editor.js in the function
-    # webreduce.editor.export_data
-    """
-    var header = {
-        template_data: {
-            template: params.template,
-            node: params.node,
-            terminal: params.terminal,
-            server_git_hash: result.server_git_hash,
-            server_mtime: new Date((result.server_mtime || 0.0) * 1000).toISOString()
-        }
-    };
-    webreduce.download('# ' + JSON.stringify(header).slice(1,-1) + '\n' + result.values.join('\n\n'), filename);
-    """
-
     # Load the template and the target output
     # note that this only works for text-based exports: others will be implemented later
     with open(filename, 'r') as fid:
-        first_line = fid.readline()
-        template_data = json.loads(TEMPLATE.sub('{', first_line))
         old_content = fid.read()
 
-    # Show the template
-    #print(json.dumps(template_data['template'], indent=2))
+    # Grab the template data from the first line
+    first_line, _ = old_content.split('\n', maxsplit=1)
+    template_data = json.loads(TEMPLATE.sub('{', first_line))
+    #import pprint; pprint.pprint(template_data)
 
-    # Make sure instrument is available
-    template_module = template_data['template']['modules'][0]['module']
-    instrument_id = template_module.split('.')[1]
-    load_instrument(instrument_id)
-
-    # run the template
-    template = Template(**template_data['template'])
-    # extract module 'refl' from ncnr.refl.module into module id
-    target = template_data['node'], template_data['terminal']
-    template_config = {}
-    retval = process_template(template, template_config, target=target)
-    # this is a hack: remove the default "column" once there are regression files
-    # that contain this metadata:
-    export_type = template_data.get("export_type", "column")
-    export = retval.get_export(headers=template_data, concatenate=True, export_type=export_type)
+    # Run the template and return the desired content.
+    prepare_dataflow(template_data['template'])
+    export = run_template(template_data, concatenate=True)
     new_content = export['values'][0]['value']
-    # remove the first line:
-    new_content = re.compile(r"^(#|//).*\n").sub("", new_content)
-    has_diff = show_diff(old_content, new_content)
+
+    # Compare old to new, ignoring the first line.
+    has_diff = compare(old_content, new_content, skip=1)
+
+    # Save the new output into the temp directory if different
+    if has_diff:  # use True to always save
+        path = os.path.join('/tmp', os.path.basename(filename))
+        save_content([{'filename': path, 'value': new_content}])
+
+    # Raise an error if different.
     if has_diff:
-        # Save the new output into athe temp directory so we can easily update
-        # the regression tests
-        new_path = os.path.join('/tmp', os.path.basename(filename))
-        with open(new_path, 'wb') as fid:
-            fid.write(encode(first_line))
-            fid.write(encode(new_content))
-        raise RuntimeError("File replay for %r differs; new file stored in %r"
-                           % (filename, new_path))
+        raise RuntimeError("File replay for %r differs" % filename)
 
 
 def find_leaves(template):
@@ -160,72 +210,51 @@ def find_leaves(template):
     return ids - sources
 
 def play_file(filename):
+    export_type = 'column'
+    concatenate = True
+
     with open(filename) as fid:
-        template_json = json.loads(fid.read())
+        template_def = json.loads(fid.read())
 
-    # Make sure instrument is available
-    template_module = template_json['modules'][0]['module']
-    instrument_id = template_module.split('.')[1]
-    load_instrument(instrument_id)
-
-    node = max(find_leaves(template_json))
-    node_module = lookup_module(template_json['modules'][node]['module'])
+    prepare_dataflow(template_def)
+    node = max(find_leaves(template_def))
+    node_module = lookup_module(template_def['modules'][node]['module'])
     terminal = node_module.outputs[0]['id']
 
-    #print(json.dumps(template_json, indent=2))
-
-    template = Template(**template_json)
-    template_config = {}
-    target = node, terminal
-    retval = process_template(template, template_config, target=target)
-    export = retval.get_export()
-
-    if export['values']:
-        basename = export['values'][0].get('name', 'replay')
-        ext = export['values'][0].get('file_suffix', '.refl') 
-        filename = basename + ext
-    else:
-        filename = 'replay.dat'
-
+    revision, timestamp = revision_info()
     template_data = {
-        'template': template_json,
+        'template': template_def,
+        'config': {},
         'node': node,
         'terminal': terminal,
-        'server_git_hash': None,
-        'server_mtime': None,
-        #server_git_hash: result.server_git_hash,
-        #server_mtime: new Date((result.server_mtime || 0.0) * 1000).toISOString()
+        'server_git_hash': revision,
+        'server_mtime': timestamp,
+        'export_type': export_type,
     }
-    first_line = '# ' + json.dumps({'template_data': template_data})[1:-1]
-    new_content = '\n\n'.join(v['export_string'] for v in export['values'])
-    with open(filename, 'wb') as file:
-        print("writing", filename)
-        file.write(encode(first_line))
-        file.write(b'\n')
-        file.write(encode(new_content))
+    export = run_template(template_data, concatenate=concatenate)
 
+    save_content(export['values'])
+
+def save_content(entries):
+    for entry in entries:
+        filename = entry['filename']
+        print("writing", filename)
+        with open(filename, 'w') as fd:
+            fd.write(entry['value'])
 
 def main():
     # type: (str) -> None
     """
     Run a regression test using the first command line as the target file.
     """
-    set_test_cache()
-    fetch.DATA_SOURCES = config.data_sources
-
     if len(sys.argv) < 2:
-        print("usage: python regression.py datafile")
+        print("usage: python regression.py (datafile|template.json)")
         sys.exit()
-    try:
-        if sys.argv[1].endswith('.json'):
-            play_file(sys.argv[1])
-        else:
-            replay_file(sys.argv[1])
+    if sys.argv[1].endswith('.json'):
+        play_file(sys.argv[1])
+    else:
+        replay_file(sys.argv[1])
         sys.exit(0)
-    except Exception as exc:
-        traceback.print_exc()
-        sys.exit(1)
-
 
 if __name__ == "__main__":
     main()

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
-import sys, os
-from os.path import join as joinpath, dirname
-import re
+import sys
+import os
+
+from setuptools import setup, find_packages
 
 if len(sys.argv) == 1:
     sys.argv.append('install')
@@ -11,15 +12,16 @@ if sys.argv[1] == 'test':
     sys.exit(call([sys.executable, '-m', 'pytest'] + sys.argv[2:]))
 #    #sys.exit(call(['test.sh'] + sys.argv[2:]))
 
+# Create the resource file dataflow/git_revision
+os.system(f'"{sys.executable}" dataflow/rev.py')
+
+# Do we need to explicitly collect resource files?  Or does setup()
+# automatically include everything when include_package_data=True?
+# package data include dataflow/git_revision, the template files, and
+# all the static content for reflweb.
+#package_data = {'dataflow': ['git_revision', ...]}
+
 #sys.dont_write_bytecode = True
-
-from setuptools import setup, find_packages
-
-import subprocess
-git_version_hash = subprocess.Popen(["git", "rev-parse", "HEAD"], stdout=subprocess.PIPE).stdout.read()
-open("reflweb/git_version_hash", "wb").write(git_version_hash)
-server_mtime = subprocess.Popen(["git", "log", "-1", "--pretty=format:%ct"], stdout=subprocess.PIPE).stdout.read()
-open("reflweb/git_version_mtime", "wb").write(server_mtime)
 
 packages = find_packages(exclude=['reflbin'])
 
@@ -54,11 +56,13 @@ dist = setup(
         'console_scripts': ['reductus=reflweb.run:main'],
     },
     install_requires=[
-        'scipy', 'numpy', 'h5py', 'uncertainties', 'docutils', 'wheel', 'pytz', 'msgpack-python', 'flask'],
+        'scipy', 'numpy', 'h5py', 'uncertainties', 'docutils',
+        'wheel', 'pytz', 'msgpack-python', 'flask',
+        ],
     extras_require={
         'masked_curve_fit': ['numdifftools'],
         },
-    tests_require = ['pytest'],
+    tests_require=['pytest'],
     )
 
 # End of file

--- a/setup.py
+++ b/setup.py
@@ -10,18 +10,9 @@ if len(sys.argv) == 1:
 if sys.argv[1] == 'test':
     from subprocess import call
     sys.exit(call([sys.executable, '-m', 'pytest'] + sys.argv[2:]))
-#    #sys.exit(call(['test.sh'] + sys.argv[2:]))
 
 # Create the resource file dataflow/git_revision
 os.system(f'"{sys.executable}" dataflow/rev.py')
-
-# Do we need to explicitly collect resource files?  Or does setup()
-# automatically include everything when include_package_data=True?
-# package data include dataflow/git_revision, the template files, and
-# all the static content for reflweb.
-#package_data = {'dataflow': ['git_revision', ...]}
-
-#sys.dont_write_bytecode = True
 
 packages = find_packages(exclude=['reflbin'])
 

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -4,9 +4,6 @@ from os import listdir
 from os.path import isfile, join as joinpath, dirname, abspath, exists
 
 import regression
-from reflweb import default_config as config
-from dataflow.cache import set_test_cache
-from dataflow import fetch
 
 try:
     import pytest
@@ -24,23 +21,19 @@ except ImportError:
 
 # Prefer not to scan regression directory on module load, but pytest doesn't
 # seem to have an interface for building tests on demand.
-REGRESSION_PATH = abspath(joinpath(dirname(__file__), 'regression_files'))
-
 def get_regression_files():
+    REGRESSION_PATH = abspath(joinpath(dirname(__file__), 'regression_files'))
     if exists(REGRESSION_PATH):
-        data_files = (f for f in listdir(REGRESSION_PATH)
-                    if isfile(joinpath(REGRESSION_PATH, f)))
+        data_files = (
+            path
+            for f in listdir(REGRESSION_PATH)
+            for path in [joinpath(REGRESSION_PATH, f)]
+            if isfile(path))
     else:
         data_files = ()
     return data_files
 
-@parametrize("filename", get_regression_files())
-def test_regression(filename):
-    set_test_cache()
-    fetch.DATA_SOURCES = config.data_sources
+@parametrize("path", get_regression_files())
+def test_regression(path):
     #description = "Regression test on %s"%path
-    path = joinpath(REGRESSION_PATH, filename)
     regression.replay_file(path)
-
-if __name__ == "__main__":
-    test_regression()


### PR DESCRIPTION
Refactor git info support, moving it to dataflow.  This allows command line utilities such as regression replay to create files with the proper template data embedded.

Refactor regression.py in preparation for testing new export types.