### PR TITLE
revert to git command line for committer date in packed repos

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
 recursive-include dataflow *.json
 recursive-include reflweb/static *.js *.html *.css
-include dataflow/git_version_*
+include dataflow/git_revision
 include */templates/*.json

--- a/dataflow/rev.py
+++ b/dataflow/rev.py
@@ -112,7 +112,7 @@ def git_rev(repo):
     the git repository changes.  It only reads files, so it should not do
     any damage to the repository in the process.
     """
-    # Based on stackoverflow am9417 and Ciro Santilli 新疆改造中心法轮功六四事件
+    # Based on stackoverflow am9417 and Ciro Santilli
     # https://stackoverflow.com/questions/14989858/get-the-current-git-hash-in-a-python-script/59950703#59950703
     # https://stackoverflow.com/questions/22968856/what-is-the-file-format-of-a-git-commit-object-data-structure/37438460#37438460
 

--- a/dataflow/rev.py
+++ b/dataflow/rev.py
@@ -46,8 +46,6 @@ Add the following to .gitignore, substituting your package name::
 
     /PACKAGE_NAME/git_revision
 
-Note: the current version doesn't handled packed repositories unless
-the git command is available on your executable path.
 """
 from pathlib import Path
 from warnings import warn

--- a/dataflow/rev.py
+++ b/dataflow/rev.py
@@ -1,9 +1,9 @@
 """
 Commit id and timestamp from the git repo.
 
-Drop the file rev.py into a top level directory of your package, right
-below the root of the repository.  From within your application you can
-then do::
+Drop the file rev.py into a top level directory PACKAGE_NAME of your
+application, right below the root of the repository.  From within your
+application you can then do::
 
     from . import rev
 
@@ -14,24 +14,25 @@ If you use a more complicated source tree then you will need to replace
 repo_path() with a function that returns the path to the repo root before
 requesting the revision information.
 
-On pip install the repo root directory may not be available.  In this
-case you need to create package/git_revision that gets installed into
-site-pacakges along with your other sources.
+On "pip install" the repo root directory will not be available. In this
+case the code looks for PACKAGE_NAME/git_revision, which you need to
+install into site-pacakges along with your other sources.
 
-The simplest way to create git_revision is to run rev from setup.py::
+The simplest way to create PACKAGE_NAME/git_revision is to run rev
+from setup.py::
 
     import sys
     import os
 
     # Create the resource file git_revision.
-    package = 'dataflow'
-    os.system(f'"{sys.executable}" {package}/rev.py')
+    os.system(f'"{sys.executable}" PACKAGE_NAME/rev.py')
 
     ...
 
-    # Include git revision in the package data.  This can be done by adding
-    # it to setup() or having "include dataflow/git_revision" in MANIFEST.in.
-    #package_data = {package: ['git_revision']}
+    # Include git revision in the package data, eitherj by adding
+    # "include PACKAGE_NAME/git_revision" to MANIFEST.in, or by
+    # adding the following to setup.py:
+    #package_data = {"PACKAGE_NAME": ["git_revision"]}
     setup(
         ...
         #package_data=package_data,
@@ -39,54 +40,22 @@ The simplest way to create git_revision is to run rev from setup.py::
         ...
     )
 
-You should add the following to .gitignore, substituting your package name::
+Add the following to .gitignore, substituting your package name::
 
-    /dataflow/git_revision
+    /PACKAGE_NAME/git_revision
 
-**Notes**
-
-If your package doesn't do a lot when you first import it, then you
-can access the methods from rev directly from setup.py instead of running
-it as a separate command::
-
-    # Add the directory containing your package root to the path
-    import sys
-    from os.path import abspath, dirname
-    sys.path.insert(0, abspath(dirname(__file__)))
-
-    from dataflow import rev
-    rev.store_rev()
-    package_data = {'dataflow': [rev.RESOURCE_NAME]}
-
-    ...
-
-Even fancier, you can load rev as a module without loading your package. This
-requires loading the module from a path on the filesystem, which is rather
-tedious::
-
-    from os.path import abspath, dirname, join as joinpath
-    import importlib.util
-
-    # Load dataflow/rev.py as a toplevel module rev (python 3.5+).
-    package = 'dataflow'
-    rev_path = joinpath(abspath(dirname(__file__)), package, 'rev.py')
-    rev_spec = importlib.util.spec_from_file_location('rev', rev_path)
-    rev = importlib.util.module_from_spec(rev_spec)
-    sys.modules['rev'] = rev
-    rev_spec.loader.exec_module(rev)
-
-    # Build the resource file dataflow/git_revision
-    rev.store_rev()
-    package_data = {package: [rev.RESOURCE_NAME]}
-
-    ...
-
+Note: the current version doesn't handled packed repositories unless
+the git command is available on your executable path.
 """
-import os.path
+from pathlib import Path
 
 def repo_path():
-    """Return path to the git repo for the project"""
-    return os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+    """Return path to the git repo for the project."""
+    base = Path(__file__).absolute()
+    for path in base.parents:
+        if (path / ".git").exists():
+            return path
+    raise ValueError(f".git not found in parent(s) of {base}")
 
 def print_revision():
     """Print the git revision and timestamp"""
@@ -100,8 +69,8 @@ def store_revision():
     See :mod:`rev` for details.
     """
     commit, timestamp = git_rev(repo_path())
-    path = os.path.abspath(os.path.join(os.path.dirname(__file__), RESOURCE_NAME))
-    with open(path, 'w') as fd:
+    path = Path(__file__).absolute().parent / RESOURCE_NAME
+    with path.open('w') as fd:
         fd.write(f"{commit} {timestamp}\n")
 
 
@@ -147,23 +116,23 @@ def git_rev(repo):
     # https://stackoverflow.com/questions/14989858/get-the-current-git-hash-in-a-python-script/59950703#59950703
     # https://stackoverflow.com/questions/22968856/what-is-the-file-format-of-a-git-commit-object-data-structure/37438460#37438460
 
-    git_root = os.path.join(repo, ".git")
-    git_head = os.path.join(git_root, "HEAD")
-    if not os.path.exists(git_head):
+    git_root = Path(repo) / ".git"
+    git_head = git_root / "HEAD"
+    if not git_head.exists():
         return None
 
     # Read .git/HEAD file
-    with open(git_head, 'r') as fd:
+    with git_head.open('r') as fd:
         head_ref = fd.read()
 
     # Find head file .git/HEAD (e.g. ref: ref/heads/master => .git/ref/heads/master)
     if not head_ref.startswith('ref: '):
-        raise RuntimeError("expected 'ref: path/to/head' in %s"%git_head)
+        raise RuntimeError(f"expected 'ref: path/to/head' in {git_head}")
     head_ref = head_ref[5:].strip()
-    head_ref = os.path.join(git_root, *head_ref.split('/'))
+    head_ref = git_root.joinpath(*head_ref.split('/'))
 
     # Read commit id from head file
-    with open(head_ref, 'r') as fd:
+    with head_ref.open('r') as fd:
         commit = fd.read().strip()
 
     # Get timestamp from commit file .git/objects/ff/fffffffffffff
@@ -178,16 +147,30 @@ def git_rev(repo):
     #
     #     {commit message lines}
     #
+    # The git repo may be packed, and the objects may not be available
+    # in the directory.  In that case they will need to be retrieved from
+    # a pack file.  The format for these files is described here:
+    #    https://git-scm.com/docs/pack-format
+    #    https://codewords.recurse.com/issues/three/unpacking-git-packfiles
+    #    https://git-scm.com/book/en/v2/Git-Internals-Packfiles
     import zlib
-    commit_ref = os.path.join(git_root, "objects", commit[:2], commit[2:])
-    with open(commit_ref, 'rb') as fd:
-        data = zlib.decompress(fd.read())
-    committer = next(v for v in data.split(b'\n') if v.startswith(b'committer'))
-    timestamp = int(committer.strip().rsplit(maxsplit=2)[-2])
+    commit_ref = git_root.joinpath("objects", commit[:2], commit[2:])
+    if commit_ref.exists():
+        with commit_ref.open('rb') as fd:
+            data = zlib.decompress(fd.read())
+        committer = next(v for v in data.split(b'\n') if v.startswith(b'committer'))
+        timestamp = int(committer.strip().rsplit(maxsplit=2)[-2])
+    else:
+        # TODO: retrieve from the pack file rather than using git log command
+        import subprocess
+        timestamp = subprocess.Popen(
+            ["git", "log", "-1", "--pretty=format:%ct"],
+            cwd=repo, stdout=subprocess.PIPE
+        ).stdout.read().strip().decode('ascii')
 
     return commit, timestamp
 
-# CRUFT: unused
+# CRUFT: unused --- use the git command rather than parsing the git files
 def git_rev_cmd(repo):
     """
     Get the git revision for the repo in the path *repo*.
@@ -201,8 +184,8 @@ def git_rev_cmd(repo):
 
     # for local and development installs of the server, the .git folder
     # will exist in parent (reduction) folder...
-    git_root = os.path.join(repo, ".git")
-    if not os.path.exists(git_root):
+    git_root = Path(repo) / ".git"
+    if not git_root.exists():
         return None
 
     revision = subprocess.Popen(

--- a/dataflow/rev.py
+++ b/dataflow/rev.py
@@ -1,5 +1,5 @@
 """
-Commit id and timestamp from the git repo.
+Get commit id from the git repo.
 
 Drop the file rev.py into a top level directory PACKAGE_NAME of your
 application, right below the root of the repository.  Set the PACKAGE_NAME
@@ -12,7 +12,7 @@ From within your application you can then do::
     from . import rev
 
     rev.print_revision()  # print the repo version
-    commit = rev.revision_info()  # return commit
+    commit = rev.revision_info()  # return commit id
 
 If you use a more complicated source tree then you will need to replace
 repo_path() with a function that returns the path to the repo root before
@@ -31,7 +31,7 @@ from setup.py::
     # Create the resource file git_revision.
     if os.system(f'"{sys.executable}" PACKAGE_NAME/rev.py') != 0:
         print("setup.py failed to build PACKAGE_NAME/git_revision", file=sys.stderr)
-        sys.exit()
+        sys.exit(1)
 
     ...
 
@@ -70,12 +70,12 @@ def store_revision():
     """
     commit = git_rev(repo_path())
     path = Path(__file__).absolute().parent / RESOURCE_NAME
-    with path.open('w') as fd:
+    with path.open("w") as fd:
         fd.write(commit + "\n")
 
 
-PACKAGE_NAME = 'dataflow'
-RESOURCE_NAME = 'git_revision'
+PACKAGE_NAME = "dataflow"
+RESOURCE_NAME = "git_revision"
 _REVISION_INFO = None # cached value of git revision
 def revision_info():
     """
@@ -94,7 +94,7 @@ def revision_info():
             import importlib_resources as resources
         try:
             revdata = resources.read_text(PACKAGE_NAME, RESOURCE_NAME)
-            commit = revdata.strip().split()[0]
+            commit = revdata.strip()
             _REVISION_INFO = commit
         except Exception:
             _REVISION_INFO = "unknown"
@@ -105,8 +105,7 @@ def git_rev(repo):
     """
     Get the git revision for the repo in the path *repo*.
 
-    Returns the commit id of the current head as well as the committer
-    timestamp as integer seconds since Jan 1 1970.
+    Returns the commit id of the current head.
 
     Note: this function parses the files in the git repository directory
     without using the git application.  It may break if the structure of
@@ -124,22 +123,22 @@ def git_rev(repo):
         return None
 
     # Read .git/HEAD file
-    with git_head.open('r') as fd:
+    with git_head.open("r") as fd:
         head_ref = fd.read()
 
     # Find head file .git/HEAD (e.g. ref: ref/heads/master => .git/ref/heads/master)
-    if not head_ref.startswith('ref: '):
+    if not head_ref.startswith("ref: "):
         warn(f"expected 'ref: path/to/head' in {git_head}")
         return None
     head_ref = head_ref[5:].strip()
 
     # Read commit id from head file
-    head_path = git_root.joinpath(*head_ref.split('/'))
+    head_path = git_root.joinpath(*head_ref.split("/"))
     if not head_path.exists():
         warn(f"path {head_path} referenced from {git_head} does not exist")
         return None
 
-    with head_path.open('r') as fd:
+    with head_path.open("r") as fd:
         commit = fd.read().strip()
 
     return commit

--- a/dataflow/rev.py
+++ b/dataflow/rev.py
@@ -2,8 +2,12 @@
 Commit id and timestamp from the git repo.
 
 Drop the file rev.py into a top level directory PACKAGE_NAME of your
-application, right below the root of the repository.  From within your
-application you can then do::
+application, right below the root of the repository.  Set the PACKAGE_NAME
+variable in this file to the package name.  For example::
+
+    PACKAGE_NAME = "dataflow"
+
+From within your application you can then do::
 
     from . import rev
 
@@ -70,6 +74,7 @@ def store_revision():
         fd.write(commit + "\n")
 
 
+PACKAGE_NAME = 'dataflow'
 RESOURCE_NAME = 'git_revision'
 _REVISION_INFO = None # cached value of git revision
 def revision_info():
@@ -88,7 +93,7 @@ def revision_info():
         except ImportError: # CRUFT: pre-3.7 requires importlib_resources
             import importlib_resources as resources
         try:
-            revdata = resources.read_text(__name__, RESOURCE_NAME)
+            revdata = resources.read_text(PACKAGE_NAME, RESOURCE_NAME)
             commit = revdata.strip().split()[0]
             _REVISION_INFO = commit
         except Exception:

--- a/reflweb/api.py
+++ b/reflweb/api.py
@@ -164,7 +164,7 @@ def calc_terminal(template_def, config, nodenum, terminal_id, return_type='full'
         return retval.get_metadata()
     elif return_type == 'export':
         # inject git version hash into export data:
-        rev_id, rev_time = revision_info()
+        rev_id = revision_info()
         template_data = {
             "template_data": {
                 "template": template_def,
@@ -172,7 +172,6 @@ def calc_terminal(template_def, config, nodenum, terminal_id, return_type='full'
                 "node": nodenum,
                 "terminal": terminal_id,
                 "server_git_hash": rev_id,
-                "server_mtime": rev_time,
                 "export_type": export_type,
                 #"datasources": fetch.DATA_SOURCES, # Is this needed?
             }

--- a/regression.py
+++ b/regression.py
@@ -82,7 +82,7 @@ def run_template(template_data, concatenate=True):
     Example::
 
         from dataflow.rev import revision_info
-        revision, timestamp = revision_info()
+        revision = revision_info()
         template_data = {
             "template": json.loads(template_str),
             "config": {}, # optional?
@@ -90,7 +90,6 @@ def run_template(template_data, concatenate=True):
             "terminal": terminal_id,
             "export_type": "column",
             "server_git_hash": revision,
-            "server_mtime": timestamp,
             "datasources": [
                 # ignored...
                 {'url': '...', 'start_path': '...', 'name': '...'},
@@ -207,14 +206,13 @@ def play_file(filename):
     node_module = lookup_module(template_def['modules'][node]['module'])
     terminal = node_module.outputs[0]['id']
 
-    revision, timestamp = revision_info()
+    revision = revision_info()
     template_data = {
         'template': template_def,
         'config': {},
         'node': node,
         'terminal': terminal,
         'server_git_hash': revision,
-        'server_mtime': timestamp,
         'export_type': export_type,
     }
     export = run_template(template_data, concatenate=concatenate)

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ if sys.argv[1] == 'test':
 # Create the resource file dataflow/git_revision
 if os.system(f'"{sys.executable}" dataflow/rev.py') != 0:
     print("setup.py failed to build dataflow/git_revision", file=sys.stderr)
-    sys.exit()
+    sys.exit(1)
 
 packages = find_packages(exclude=['reflbin'])
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,9 @@ if sys.argv[1] == 'test':
     sys.exit(call([sys.executable, '-m', 'pytest'] + sys.argv[2:]))
 
 # Create the resource file dataflow/git_revision
-os.system(f'"{sys.executable}" dataflow/rev.py')
+if os.system(f'"{sys.executable}" dataflow/rev.py') != 0:
+    print("setup.py failed to build dataflow/git_revision", file=sys.stderr)
+    sys.exit()
 
 packages = find_packages(exclude=['reflbin'])
 


### PR DESCRIPTION
The pure python git rev code doesn't handle packed repos.  Instead fall back to git command line in this case.

Also changes to using pathlib interface for paths.  This lets us put rev.py anywhere in the tree, which may be useful when we borrow it into other projects.