### PR TITLE
reflred: improve resolution handling on join

### DIFF
--- a/reflred/candor.py
+++ b/reflred/candor.py
@@ -465,46 +465,38 @@ class Candor(ReflData):
     def to_column_text(self):
         pass
 
-class QData(ReflData):
-    def __init__(self, data, q, dq, v, dv, ti=None, dt=None, ld=None, dl=None):
-        super().__init__()
-        self.probe = data.probe
-        self.path = data.path
-        self.uri = data.uri
-        self.name = data.name
-        self.entry = data.entry
-        self.description = data.description
-        self.polarization = data.polarization
-        self.normbase = data.normbase
-        self.v = v
-        self.dv = dv
-        self.intent = Intent.spec
-        self.points = len(q)
-        self.scan_value = []
-        self.scan_units = []
-        self.scan_label = []
-        # Put angles and resolution in the appropriate places in the refldata
-        # data structure.
-        self.sample = copy(data.sample)
-        self.sample.angle_x = ti
-        self.sample.angle_x_target = ti
-        self.angular_resolution = dt
-        self.detector = Detector()
-        self.detector.wavelength = ld
-        self.detector.wavelength_resolution = dl
-        self.detector.angle_x = 2*ti
-        self.detector.angle_x_target = 2*ti
-        # Since dq is not computed directly from dt and dl, we need to store
-        # it specially. Need to override apply_mask to fix up dq.
-        self._dq = dq
-
-    @property
-    def dQ(self):
-        return self._dq
-
-    def apply_mask(self, mask_indices):
-        self._dq = np.delete(self._dq, mask_indices)
-        ReflData.apply_mask(self, mask_indices)
+def QData(data, q, dq, v, dv, ti=None, dt=None, ld=None, dl=None):
+    self = ReflData()
+    self.probe = data.probe
+    self.path = data.path
+    self.uri = data.uri
+    self.name = data.name
+    self.entry = data.entry
+    self.description = data.description
+    self.polarization = data.polarization
+    self.normbase = data.normbase
+    self.v = v
+    self.dv = dv
+    self.intent = data.intent
+    self.points = len(q)
+    self.scan_value = []
+    self.scan_units = []
+    self.scan_label = []
+    # Put angles and resolution in the appropriate places in the refldata
+    # data structure.
+    self.sample = copy(data.sample)
+    self.sample.angle_x = ti
+    self.sample.angle_x_target = ti
+    self.angular_resolution = dt
+    self.detector = Detector()
+    self.detector.wavelength = ld
+    self.detector.wavelength_resolution = dl
+    self.detector.angle_x = 2*ti
+    self.detector.angle_x_target = 2*ti
+    # Since dq is not computed directly from dt and dl, we need to store
+    # it specially. Need to override apply_mask to fix up dq.
+    self.dQ = dq
+    return self
 
 def nobin(data):
     """

--- a/reflred/joindata.py
+++ b/reflred/joindata.py
@@ -59,13 +59,16 @@ def join_datasets(group, Qtol, dQtol, by_Q=False):
     #print "joining files in",group[0].path,group[0].name,group[0].entry
     # Make sure all datasets are normalized by the same factor.
     normbase = group[0].normbase
-    assert all(data.normbase == normbase for data in group), "can't mix time and monitor normalized data"
+    assert all(data.normbase == normbase for data in group), \
+        "can't mix time and monitor normalized data"
 
     # Gather the columns
     fields = get_fields(group)
     env = get_env(group)
     fields.update(env)
     columns = stack_columns(group, fields)
+
+    # TODO: why is there a mask that hasn't been applied?
     columns = apply_mask(group, columns)
     columns = set_QdQ(columns)
 
@@ -111,6 +114,7 @@ def join_datasets(group, Qtol, dQtol, by_Q=False):
     columns = sort_columns(columns, keys)
 
     data = build_dataset(group, columns, normbase)
+
     #print "joined",data.intent
     return data
 
@@ -159,9 +163,10 @@ def build_dataset(group, columns, norm):
     #data.description
     data.date = min(d.date for d in group)  # set date to earliest date
     data.duration = sum(d.duration for d in group)  # cumulative duration
-    data.polarization = (head.polarization
-                         if all(d.polarization == head.polarization for d in group)
-                         else '')
+    data.polarization = (
+        head.polarization
+        if all(d.polarization == head.polarization for d in group)
+        else '')
     #data.normbase
     data.warnings = []  # initialize per-file history
     #data.vlabel
@@ -261,6 +266,9 @@ def build_dataset(group, columns, norm):
             # TODO: could maybe join the environment logs
             # ----- this would require setting them all to a common start time
 
+    if 'dQ' in columns:
+        data.dQ = columns['dQ']
+
     return data
 
 
@@ -295,6 +303,9 @@ def get_fields(group):
         v=[data.v for data in group],
         dv=[data.dv for data in group],
     )
+    # HACK: binned QData has _dq field that won't match the computed dQ
+    if any(hasattr(data, '_dq') for data in group):
+        columns['dQ'] = [data.dQ for data in group]
     # TODO: cleaner way of handling multi-channel detectors
     if columns['v'][0].ndim > 1:
         # For candor analysis (and anything else with an nD detector), pick
@@ -351,7 +362,7 @@ def get_env(group):
 def stack_columns(group, columns):
     # type: (List[ReflData], Columns) -> StackedColumns
     """
-    Join individual datasets into only long vector for each field in columns.
+    Join individual datasets into one long vector for each field in columns.
     """
     columns = dict((field, [_scalar_to_vector(part, data, field)
                             for part, data in zip(values, group)])
@@ -399,15 +410,16 @@ def apply_mask(group, columns):
 def set_QdQ(columns):
     # type: (StackedColumns) -> StackedColumns
     """
-    Generate Q and dQ fields from angles and geometry
+    Generate Q and dQ fields from angles and geometry.
     """
-    Ti, Td, dT = columns['Ti'], columns['Td'], columns['dT']
-    Ld, dL = columns['Ld'], columns['dL']
-    #print("set_QdQ", [v.shape for v in (Ti, Td, dT, Ld, dL)])
+    # TODO: should use Qz_basis for choosing Ti vs Ti_target, etc.
+    Ti, Td, Ld = columns['Ti'], columns['Td'], columns['Ld']
     Qx, Qz = TiTdL2Qxz(Ti, Td, Ld)
+    columns['Qx'], columns['Qz'] = Qx, Qz
     # TODO: is dQx == dQz ?
-    dQ = dTdL2dQ(Td-Ti, dT, Ld, dL)
-    columns['Qx'], columns['Qz'], columns['dQ'] = Qx, Qz, dQ
+    if not hasattr(columns, 'dQ'):
+        dT, dL = columns['dT'], columns['dL']
+        columns['dQ'] = dTdL2dQ(Td-Ti, dT, Ld, dL)
     return columns
 
 
@@ -590,26 +602,60 @@ def merge_points(index_sets, columns, normbase):
             results['dv'].append(dv)
             results['time'].append(np.sum(columns['time'][group]))
             results['monitor'].append(np.sum(columns['monitor'][group]))
-            # TODO: dQ should increase when points are mixed (see MERGE below)
             w = weight[group]
             for key, value in columns.items():
-                if key not in ['v', 'dv', 'time', 'monitor']:
+                if key in ('Ti', 'Li', 'Qz', 'T', 'L'):
+                    # When mixing angle, wavelength and Q use a gaussian
+                    # mixture model to compute the associated resolution
+                    # for dT, dL and dQ. This allows you to compute a
+                    # realistic resolution width when the resolution from the
+                    # individual points are not centered around the same value.
+                    # This is an issue when binning Q values: the width of the
+                    # resulting distribution needs to be at least as wide as
+                    # the range of Q values in the bin.
+                    #
+                    # We use incident wavelength and incident angle for the
+                    # wavelength and angle distribution.
+                    # TODO: Remove T and L since they are no longer used.
+                    #
+                    # Note: the mapping between field and resolution,
+                    # {Ti: dT, Li: dL, Qz: dQ}, can conveniently be captured
+                    # using 'd' plus the first letter of the field.
+                    variance_key = 'd' + key[:1]
+                    variance = columns[variance_key]
+                    x, dx = _merge_variance(value[group], variance[group], w)
+                    results[key].append(x)
+                    results[variance_key].append(dx)
+                elif key in ['v', 'dv', 'time', 'monitor', 'dT', 'dL', 'dQ']:
+                    # v, dv, time and monitor are handled outside the loop.
+                    # dT, dL and dQ are handled in the above variance merge.
+                    pass
+                else:
                     results[key].append(np.average(value[group], weights=w, axis=0))
 
     # Turn lists into arrays
     results = dict((k, np.array(v)) for k, v in results.items())
     return results
 
-# MERGE variance
-#
-# There is a simple expression for the moments of a mixture of distributions:
-#     T = (sum wk . T) / (sum wk)
-#     dT^2 = (sum wk . (dTk^2 + Tk^2)) / (sum wk) - T^2
-# See: https://en.wikipedia.org/wiki/Mixture_density#Moments
-#
-# This formula should be applied to angular distribution since that is
-# the quantity being mixed when combining measurements at slightly
-# different angles.
+def _merge_variance(x, dx, w):
+    """
+    Merge points x with variance dx and weight w.
+
+    Use this simple expression for the moments of a mixture of distributions::
+
+        T = (sum wk . Tk) / (sum wk)
+        dT^2 = (sum wk . (dTk^2 + Tk^2)) / (sum wk) - T^2
+
+    See: https://en.wikipedia.org/wiki/Mixture_density#Moments
+
+    This formula should be applied to angular distribution since that is
+    the quantity being mixed when combining measurements at slightly
+    different angles.
+    """
+    wsum = np.sum(w, axis=0)
+    x_bar = np.sum(w*x, axis=0) / wsum
+    varx_bar = np.sum(w*(dx**2 + x**2), axis=0) / wsum - x_bar**2
+    return x_bar, np.sqrt(varx_bar)
 
 def sort_columns(columns, keys):
     # type: (StackedColumns, Sequence[str]) -> StackedColumns

--- a/reflred/refldata.py
+++ b/reflred/refldata.py
@@ -824,6 +824,8 @@ class ReflData(Group):
     _intent = Intent.none
     _v = None
     _dv = None
+    # _dq is used when resolution can't be computed from dT and dL
+    _dq = None  # type: Optional[np.ndarray]
 
     ## Data representation for generic plotter as (x,y,z,v) -> (qz,qx,qy,Iq)
     ## TODO: subclass Data so we get pixel edges calculations
@@ -934,7 +936,6 @@ class ReflData(Group):
     def Qz(self):
         # Note: specular reflectivity assumes elastic scattering
         Li = Ld = self.Ld
-        #print("Qz_basis", self.Qz_basis, self.Ti.shape, self.Td.shape, self.Ti_target.shape, self.Td_target.shape, Li.shape)
         if self.Qz_basis == 'actual':
             return calc_Qz(self.Ti, self.Td, Li, Ld)
         if self.Qz_basis == 'target':
@@ -970,6 +971,8 @@ class ReflData(Group):
 
     @property
     def dQ(self):
+        if self._dq is not None:
+            return self._dq
         if self.angular_resolution is None:
             return None
             #raise ValueError("Need to estimate divergence before requesting dQ")
@@ -978,6 +981,10 @@ class ReflData(Group):
         L, dL = self.Ld, self.detector.wavelength_resolution
         #print(T.shape, dT.shape, L.shape, dL.shape)
         return dTdL2dQ(T, dT, L, dL)
+
+    @dQ.setter
+    def dQ(self, dQ):
+        self._dq = dQ
 
     @property
     def columns(self):
@@ -991,7 +998,8 @@ class ReflData(Group):
             ('Qx', {'label': 'Qx', 'units': "1/Ang"}),
             ('angular_resolution', {'label': 'Angular Resolution (1-sigma)', 'units': 'degrees'})
         ])
-        # TODO: duplicate code in columns, apply_mask and refldata._group
+        # TODO: duplicate code in columns & apply_mask
+        # TODO: list of groups mostly follows ReflData._group
         for subclsnm in ['sample', 'detector', 'monitor', 'slit1', 'slit2', 'slit3', 'slit4', 'monochromator']:
             subcls = getattr(self, subclsnm, None)
             if subcls is None:
@@ -1026,7 +1034,7 @@ class ReflData(Group):
             mask[mask_indices] = False
             return mask
 
-        for prop in ['_v', '_dv', 'angular_resolution', 'Qz_target']:
+        for prop in ['_v', '_dv', '_dq', 'angular_resolution', 'Qz_target']:
             v = getattr(self, prop, None)
             if check_array(v):
                 # TODO: use numpy.delete(v, indices) instead
@@ -1036,6 +1044,8 @@ class ReflData(Group):
 
         self.scan_value = [v[make_mask(v, mask_indices)] if check_array(v) else v for v in self.scan_value]
 
+        # TODO: duplicate code in columns & apply_mask
+        # TODO: list of groups mostly follows ReflData._group
         for subclsnm in ['sample', 'detector', 'monitor', 'slit1', 'slit2', 'slit3', 'slit4', 'monochromator']:
             subcls = getattr(self, subclsnm, None)
             if subcls is None:
@@ -1199,7 +1209,7 @@ class ReflData(Group):
             else:
                 _write_key_value(fid, "columns", [self.xlabel, self.vlabel, "uncertainty", "resolution"])
                 _write_key_value(fid, "units", [self.xunits, self.vunits, self.vunits, self.xunits])
-                data = np.vstack([self.x, self.v, self.dv, self.dx]).T
+                data = np.vstack((self.x, self.v, self.dv, self.dx)).T
                 np.savetxt(fid, data, fmt="%.10e")
                 suffix = ".refl"
             value = fid.getvalue()

--- a/regression.py
+++ b/regression.py
@@ -266,7 +266,7 @@ def main():
     if len(sys.argv) < 2:
         print("usage: python regression.py (datafile|template.json)")
         sys.exit(1)
-    if sys.argv[1].endswith('.json'):
+    if sys.argv[1].endswith('.json') or sys.argv[1].endswith('.json.txt'):
         # Don't know if this is a template or an export...
         play_file(sys.argv[1])
     else:


### PR DESCRIPTION
Redo the join algorithm so that Δθ, Δλ, and ΔQ are computed from the [variance of the mixture distribution](https://en.wikipedia.org/wiki/Mixture_density#Moments).

This is necessary when binning a high density dataset down to a lower dataset. If done properly, this should be equivalent to the candor binning with the same bin edges (untested---the bin edges produced by join will not in general match those used for candor binning).

This patch updates the candor binning result so that it produces a normal refldata structure rather than a specialized Qdata structure.

There is currently special handling of theta for joining prior to binning on candor. This could perhaps be simplified.

I'm setting this PR to draft until it is more thoroughly tested.