### PR TITLE
Expand dark_current module for use with 1D data

### DIFF
--- a/reflred/candor_steps.py
+++ b/reflred/candor_steps.py
@@ -104,7 +104,7 @@ def candor(
         if auto_divergence:
             data = steps.divergence_fb(data, sample_width)
         if dc_rate != 0. or dc_slope != 0.:
-            data = steps.dark_current([data], dc_rate, dc_slope)[0]       # now requires a list of datasets; could move it out of the for loop
+            data = steps.dark_current([data], dc_rate, dc_slope)[0][0]       # now requires and returns a list of datasets; could move it out of the for loop
         if detector_correction:
             data = steps.detector_dead_time(data, None)
         if monitor_correction:

--- a/reflred/candor_steps.py
+++ b/reflred/candor_steps.py
@@ -104,7 +104,7 @@ def candor(
         if auto_divergence:
             data = steps.divergence_fb(data, sample_width)
         if dc_rate != 0. or dc_slope != 0.:
-            data = steps.dark_current([data], dc_rate, dc_slope)[0][0]       # now requires and returns a list of datasets; could move it out of the for loop
+            data = steps.dark_current([data], poly_coeff=[dc_slope, dc_rate])[0][0]       # now requires and returns a list of datasets; could move it out of the for loop
         if detector_correction:
             data = steps.detector_dead_time(data, None)
         if monitor_correction:


### PR DESCRIPTION
The dark_current module is used for subtracting slit1-dependent dark counts in the candor loader, or as a standalone module (but for a single dataset).

This update expands the dark_current module to handle refldata[] lists from either MAGIK or CANDOR (not tested on other instruments), and allows it to be used in a workflow immediately after the loader (rather than requiring it to be incorporated into the loader).

It has been tested both on Candor data (only in the loader), and on Magik data as part of the workflow.

Also, because of its more general nature now, it was moved from candor_steps to steps.

The first commit in this PR creates a separate module for 1D data, subtract_dark_counts, that is replaced by the updated dark_current in the last commit.

Not done: Uncertainty propagation may still be important, or perhaps recalculating the uncertainties based on the dark-current-subtracted values. Also there's a TODO for datatype hierarchy that I am not sure what it means.