### PR TITLE
correct divergence for continous scanning reflectometers

### DIFF
--- a/reflred/candor.py
+++ b/reflred/candor.py
@@ -466,7 +466,8 @@ class Candor(ReflData):
         pass
 
 class QData(ReflData):
-    def __init__(self, data, q, dq, v, dv, ti=None, dt=None, ld=None, dl=None):
+    def __init__(self, data, q, dq, v, dv, ti=None, dt=None, ld=None, dl=None,
+            resolution_shape='normal'):
         super().__init__()
         self.probe = data.probe
         self.path = data.path
@@ -497,6 +498,7 @@ class QData(ReflData):
         # Since dq is not computed directly from dt and dl, we need to store
         # it specially. Need to override apply_mask to fix up dq.
         self._dq = dq
+        self.resolution_shape = resolution_shape
 
     @property
     def dQ(self):
@@ -523,7 +525,7 @@ def nobin(data):
         index = np.argsort(columns_bank[0])
         columns_bank = [p[index] for p in columns_bank]
         Qx, dQ, v, dv, Ti, dT, L, dL = columns_bank
-        datasets.append(QData(data, Qx, dQ, v, dv, Ti, dT, L, dL))
+        datasets.append(QData(data, Qx, dQ, v, dv, Ti, dT, L, dL, 'normal'))
 
     # Only look at bank 0 for now
     return datasets[0]
@@ -540,7 +542,11 @@ def rebin(data, q, average="poisson"):
         #output = ReflData()
         #output.v, output.dv = v, dv
         #output.x, output.dx = q, dq
-        datasets.append(QData(data, qz, dq, v, dv, Ti, dT, L, dL))
+        # Assume rebinned data will be approximately uniform. This is not
+        # true particularly at the end points where there may be a single
+        # value per bin, but for those cases the resolution ought to be tight
+        # enough that the convolution has minimimal effect.
+        datasets.append(QData(data, qz, dq, v, dv, Ti, dT, L, dL, 'uniform'))
 
     # Only look at bank 0 for now
     return datasets[0]

--- a/reflred/refldata.py
+++ b/reflred/refldata.py
@@ -796,6 +796,9 @@ class ReflData(Group):
     mask = None
     #: Computed 1-sigma angular resolution in degrees
     angular_resolution = None  # type: np.ndarray
+    #: Resolution shape. For now just 'uniform' or 'normal', with a shared
+    #: value for every point. In practice it is more complicated than that.
+    resolution_shape = 'normal'
     #: Hint for axis to use for aligning data with intensity scans:
     align_intensity = 'angular_resolution'
     #: For background scans, the choice of Qz for the
@@ -1175,6 +1178,11 @@ class ReflData(Group):
                 _write_key_value(fid, "angle", self.Ti)
             if self.angular_resolution is not None:
                 _write_key_value(fid, "angular_resolution", self.angular_resolution)
+            # TODO: should we always record resolution shape?
+            # Note: only recording resolution shape if it is not the default (normal)
+            # so that regression tests don't fail.
+            if self.resolution_shape != 'normal':
+                _write_key_value(fid, "resolution_shape", self.resolution_shape)
             if Intent.isscan(self.intent):
                 _write_key_value(fid, "columns", list(self.columns.keys()))
                 _write_key_value(fid, "units", [c.get("units", "") for c in self.columns.values()])


### PR DESCRIPTION
Continuous scanning reflectometers will have broader resolution than indicated by simple slits, and resolution will be closer to uniform than normal. See #129.

Note: this needs to be tested against Rigaku and Bruker continuous scan measurements before merging.