### PR TITLE
Source divergence

### DIFF
--- a/reflred/angles.py
+++ b/reflred/angles.py
@@ -1,5 +1,5 @@
 import numpy as np
-from .resolution import divergence, divergence_simple
+from .resolution import divergence, divergence_simple, FWHM2sigma
 
 def apply_theta_offset(data, offset):
     data.sample.angle_x += offset
@@ -37,6 +37,8 @@ def apply_divergence_simple(data, sample_width):
     dtheta = divergence_simple(slits=slits, distance=distance, T=theta,
                                sample_width=sample_width, use_sample=use_sample)
     #print("divergence", theta.shape, dtheta.shape)
+    if data.source_divergence is not None:
+        dtheta = np.minimum(dtheta, FWHM2sigma(data.source_divergence/2))
     data.angular_resolution = dtheta
 
 def apply_sample_broadening(data, sample_broadening):

--- a/reflred/footprint.py
+++ b/reflred/footprint.py
@@ -213,9 +213,10 @@ def _abinitio_footprint(slit1, slit2, theta, width, offset=0., source_divergence
     rotation of the sample away from the beam center.  These are in the same
     units as the slits (mm).
 
-    *source_divergence* is the angular divergence of the source, in degrees
-    (e.g. from a parabolic mirror between the true source and the beamline)
-    The beam is assumed to have uniform intensity for the entire width.
+    *source_divergence* is the angular divergence of the source (1-sigma)
+    in degrees (e.g. from a parabolic mirror between the true source 
+    and the beamline).  The beam is assumed to have uniform intensity 
+    for the entire width.
     """
     # TODO: implement footprint for circular samples
     # TODO: implement vertical footprint if slit y is not inf
@@ -224,7 +225,8 @@ def _abinitio_footprint(slit1, slit2, theta, width, offset=0., source_divergence
     d2, s2x, s2y = slit2
 
     # for some reason, distances are stored in nexus files with float32 precision,
-    # causing roundoff errors in this calculation
+    # causing noticeable roundoff differences between different orders of operation
+    # (which affects the reproducibility tests, when the algorithm is altered.)
     if hasattr(d1, 'astype'):
         d1 = d1.astype(np.float64)
     if hasattr(d2, 'astype'):

--- a/reflred/footprint.py
+++ b/reflred/footprint.py
@@ -196,7 +196,7 @@ def apply(fp, R):
     return corrected_y, corrected_dy
 
 
-def _abinitio_footprint(slit1, slit2, theta, width, offset=0.):
+def _abinitio_footprint(slit1, slit2, theta, width, offset=0., source_divergence=None):
     """
     Ab-initio footprint calculation from slits, angles and sample size.
 
@@ -212,6 +212,10 @@ def _abinitio_footprint(slit1, slit2, theta, width, offset=0.):
     *width* is the width of the sample. *offset* is a shift in the center of
     rotation of the sample away from the beam center.  These are in the same
     units as the slits (mm).
+
+    *source_divergence* is the angular divergence of the source, in degrees
+    (e.g. from a parabolic mirror between the true source and the beamline)
+    The beam is assumed to have uniform intensity for the entire width.
     """
     # TODO: implement footprint for circular samples
     # TODO: implement vertical footprint if slit y is not inf
@@ -228,15 +232,37 @@ def _abinitio_footprint(slit1, slit2, theta, width, offset=0.):
     p_near = (-width / 2 + offset) * sin(theta)
     p_far = (+width / 2 + offset) * sin(theta)
 
-    # beam profile is a trapezoid, 0 where a neutron entering at -s1/2 just
-    # misses s2/2, and 1 where a neutron entering at s1/2 just misses s2/2.
-    # With tiny front slits, the projection h2 may land on the other side
-    # of the beam center.  In this case the overall instensity is lower, but
-    # the trapezoid happens to have the same shape, with the flat region
-    # extending from -abs(w2) to abs(w2).  Since we only care about intensity
-    # relative to the beam for footprint correction, the scale factor cancels.
-    w1 = abs(d1/(d1-d2))*(s1x + s2x) / 2 - s1x / 2
-    w2 = abs(-abs(d1/(d1-d2)) * (s1x - s2x) / 2 + s1x / 2)
+    # source divergence sets a limit on all angles in the problem:
+    source_divergence = 180.0 if source_divergence is None else abs(source_divergence)
+    print('source_divergence: ', source_divergence)
+    source_max_slope = np.tan(np.radians(source_divergence/2))
+    print('source_max_slope: ', source_max_slope)
+    print('s1: ', s1x, d1)
+    print('s2: ', s2x, d2)
+
+    # slope between opposite edges of slits 1 and 2:
+    # (i.e. bottom of slit 1, top of slit 2) - always positive
+    outer_slope = (s2x + s1x) / np.abs(d1 - d2) / 2
+    print('outer slope: ', outer_slope)
+    outer_slope = np.minimum(outer_slope, source_max_slope)
+    print('outer slope: ', outer_slope)
+
+    # slope between similar edges of slits 1 and 2 
+    # (both tops) - will be positive if s1x < s2x
+    inner_slope = (s2x - s1x) / np.abs(d1 - d2) / 2
+    # constrain the slope so that it is never larger than the source div.
+    # (-source_max_slope <= inner_slope <= source_max_slope)
+    inner_slope = np.maximum(-source_max_slope, np.minimum(inner_slope, source_max_slope))
+
+    # Beam profile is a trapezoid, with control points defined by where
+    # the inner_slope and outer_slope intersect the sample position, subject
+    # to the constraint that they must pass below both the top slit 1 and 
+    # slit 2 edges. The lower projected value will be the constraining one...
+    w1 = np.abs(np.minimum(s1x/2 + np.abs(outer_slope * d1), s2x/2 + np.abs(outer_slope * d2)))
+    w2 = np.abs(np.minimum(s1x/2 + np.abs(inner_slope * d1), s2x/2 + np.abs(inner_slope * d2)))
+    print('w1: ', w1)
+    print('w2: ', w2)
+    
     w_intensity = w1 + w2
     #if use_y:
     #    h1 = abs(d1/(d1-d2))*(s1y+s2y)/2 - s1y/2

--- a/reflred/footprint.py
+++ b/reflred/footprint.py
@@ -104,17 +104,19 @@ def apply_measured_footprint(data, measured_footprint):
     _apply_footprint(data, footprint)
 
 
-def apply_abinitio_footprint(data, Io, width, offset):
+def apply_abinitio_footprint(data, Io, width, offset, source_divergence=None):
     slit1 = (data.slit1.distance, data.slit1.x, data.slit1.y)
     slit2 = (data.slit2.distance, data.slit2.x, data.slit2.y)
     theta = data.sample.angle_x
+    if source_divergence is None:
+        source_divergence = data.source_divergence
     if width is None:
         width = data.sample.width
     if offset is None:
         offset = 0.
     if Io is None:
         Io = 1.
-    y = Io * _abinitio_footprint(slit1, slit2, theta, width, offset)
+    y = Io * _abinitio_footprint(slit1, slit2, theta, width, offset, source_divergence=source_divergence)
     footprint = U(y, 0.0*y)
     _apply_footprint(data, footprint)
 
@@ -213,7 +215,7 @@ def _abinitio_footprint(slit1, slit2, theta, width, offset=0., source_divergence
     rotation of the sample away from the beam center.  These are in the same
     units as the slits (mm).
 
-    *source_divergence* is the angular divergence of the source (1-sigma)
+    *source_divergence* is the angular divergence of the source (full-width)
     in degrees (e.g. from a parabolic mirror between the true source 
     and the beamline).  The beam is assumed to have uniform intensity 
     for the entire width.
@@ -248,7 +250,6 @@ def _abinitio_footprint(slit1, slit2, theta, width, offset=0., source_divergence
     # slope between opposite edges of slits 1 and 2:
     # (i.e. bottom of slit 1, top of slit 2) - always positive
     outer_slope = (s2x + s1x) / np.abs(d1 - d2) / 2
-    outer_angle = np.arctan2((s2x + s1x)/2, np.abs(d1-d2))
 
     outer_slope = np.minimum(outer_slope, source_max_slope)
 

--- a/reflred/footprint.py
+++ b/reflred/footprint.py
@@ -253,15 +253,22 @@ def _abinitio_footprint(slit1, slit2, theta, width, offset=0., source_divergence
     # constrain the slope so that it is never larger than the source div.
     # (-source_max_slope <= inner_slope <= source_max_slope)
     inner_slope = np.maximum(-source_max_slope, np.minimum(inner_slope, source_max_slope))
+    print('inner slope: ', inner_slope)
+
 
     # Beam profile is a trapezoid, with control points defined by where
     # the inner_slope and outer_slope intersect the sample position, subject
     # to the constraint that they must pass below both the top slit 1 and 
     # slit 2 edges. The lower projected value will be the constraining one...
-    w1 = np.abs(np.minimum(s1x/2 + np.abs(outer_slope * d1), s2x/2 + np.abs(outer_slope * d2)))
-    w2 = np.abs(np.minimum(s1x/2 + np.abs(inner_slope * d1), s2x/2 + np.abs(inner_slope * d2)))
+    w1 = np.abs(np.minimum(s1x/2 + outer_slope * np.abs(d1), s2x/2 + outer_slope * np.abs(d2)))
+    print('w1 choices: ', -s1x/2 + outer_slope * np.abs(d1), s2x/2 + outer_slope * np.abs(d2))
+    w2 = np.abs(np.minimum(s1x/2 + inner_slope * np.abs(d1), s2x/2 + inner_slope * np.abs(d2)))
+    print('w2 choices: ', s1x/2 + inner_slope * np.abs(d1), s2x/2 + inner_slope * np.abs(d2))
     print('w1: ', w1)
+    print('old w1: ', abs(d1/(d1-d2))*(s1x + s2x) / 2 - s1x / 2)
     print('w2: ', w2)
+    print('old w2: ', abs(-abs(d1/(d1-d2)) * (s1x - s2x) / 2 + s1x / 2))
+
     
     w_intensity = w1 + w2
     #if use_y:

--- a/reflred/footprint.py
+++ b/reflred/footprint.py
@@ -241,21 +241,14 @@ def _abinitio_footprint(slit1, slit2, theta, width, offset=0., source_divergence
 
     # source divergence sets a limit on all angles in the problem:
     source_divergence = 180.0 if source_divergence is None else abs(source_divergence)
-    print('source_divergence: ', source_divergence)
     source_max_slope = np.tan(np.radians(source_divergence/2))
-    print('source_max_slope: ', source_max_slope)
-    print('s1: ', s1x, d1, s1x.dtype, d1.dtype)
-    print('s2: ', s2x, d2, s2x.dtype, d2.dtype)
 
     # slope between opposite edges of slits 1 and 2:
     # (i.e. bottom of slit 1, top of slit 2) - always positive
     outer_slope = (s2x + s1x) / np.abs(d1 - d2) / 2
     outer_angle = np.arctan2((s2x + s1x)/2, np.abs(d1-d2))
-    print('outer slope: ', outer_slope)
-    print('outer angle: ', outer_angle)
 
     outer_slope = np.minimum(outer_slope, source_max_slope)
-    print('outer slope: ', outer_slope)
 
     # slope between similar edges of slits 1 and 2 
     # (both tops) - will be positive if s1x < s2x
@@ -263,7 +256,6 @@ def _abinitio_footprint(slit1, slit2, theta, width, offset=0., source_divergence
     # constrain the slope so that it is never larger than the source div.
     # (-source_max_slope <= inner_slope <= source_max_slope)
     inner_slope = np.maximum(-source_max_slope, np.minimum(inner_slope, source_max_slope))
-    print('inner slope: ', inner_slope)
 
 
     # Beam profile is a trapezoid, with control points defined by where
@@ -271,15 +263,7 @@ def _abinitio_footprint(slit1, slit2, theta, width, offset=0., source_divergence
     # to the constraint that they must pass below both the top slit 1 and 
     # slit 2 edges. The lower projected value will be the constraining one...
     w1 = np.abs(np.minimum(s1x/2 + outer_slope * np.abs(d1), s2x/2 + outer_slope * np.abs(d2)))
-    print('w1 choices: ', (outer_slope * np.abs(d1)) - s1x/2, np.tan(outer_angle) * np.abs(d1) - s1x/2, s2x/2 + outer_slope * np.abs(d2))
     w2 = np.abs(np.minimum(s1x/2 + inner_slope * np.abs(d1), s2x/2 + inner_slope * np.abs(d2)))
-    print('w2 choices: ', s1x/2 + inner_slope * np.abs(d1), s2x/2 + inner_slope * np.abs(d2))
-    print('w1: ', w1)
-    print('old w1: ', abs(d1/(d1-d2))*(s1x + s2x) / 2 - s1x / 2)
-    print('w1 diffs: ', (outer_slope * abs(d1)), abs(d1/(d1-d2))*(s1x + s2x)/2)
-    print('w2: ', w2)
-    print('old w2: ', abs(-abs(d1/(d1-d2)) * (s1x - s2x) / 2 + s1x / 2))
-
     
     w_intensity = w1 + w2
     #if use_y:

--- a/reflred/refldata.py
+++ b/reflred/refldata.py
@@ -796,6 +796,9 @@ class ReflData(Group):
     mask = None
     #: Computed 1-sigma angular resolution in degrees
     angular_resolution = None  # type: np.ndarray
+    #: Source divergence (for systems with e.g. mirror optics)
+    #: as a full-width in degrees
+    source_divergence = None
     #: Hint for axis to use for aligning data with intensity scans:
     align_intensity = 'angular_resolution'
     #: For background scans, the choice of Qz for the

--- a/reflred/steps.py
+++ b/reflred/steps.py
@@ -1379,7 +1379,7 @@ def smooth_slits(datasets, degree=1, span=2, dx=0.01):
 
 
 @module
-def abinitio_footprint(data, Io=1., width=None, offset=0.):
+def abinitio_footprint(data, Io=1., width=None, offset=0., source_divergence=None):
     """
     Apply an *ab initio* footprint correction to the data.
 
@@ -1405,16 +1405,21 @@ def abinitio_footprint(data, Io=1., width=None, offset=0.):
     offset (float:mm) : offset of the center of rotation of the sample in
     the direction of the beam, toward the detector.
 
+    source_divergence {source divergence (deg, full width)} (float?) : override the
+    source divergence found in the data.  Fill in this value if your divergence
+    is known and was not entered on load
+
     **Returns**
 
     outputs (refldata): footprint-corrected data
 
-    2016-09-02 Paul Kienzle
+    | 2016-09-02 Paul Kienzle
+    | 2022-02-08 Brian Maranville add source_divergence input
     """
     from .footprint import apply_abinitio_footprint
 
     data = copy(data)
-    apply_abinitio_footprint(data, Io, width, offset)
+    apply_abinitio_footprint(data, Io, width, offset, source_divergence)
     return data
 
 @module

--- a/reflred/xrawref.py
+++ b/reflred/xrawref.py
@@ -304,6 +304,7 @@ class RigakuRefl(refldata.ReflData):
         self.detector.angle_x_target = self.detector.angle_x
         self.Qz_target = np.NaN
 
+FULLY_OPEN_SLIT = 1000. # a semi-infinite opening for a slit; used if that slit is not present.
 
 class XRDMLRefl(refldata.ReflData):
     """
@@ -332,12 +333,13 @@ class XRDMLRefl(refldata.ReflData):
 
         self.description = entry['comment']
         self.instrument = 'Malvern Panalytical'
-        # 1-sigma angular resolution (degrees) reported by Bruker.  Our own
-        # measurements give a similar value (~ 0.033 degrees FWHM)
-        #nominal_resolution = 0.03
+
         self.angular_resolution = None
+        # full-width source divergence (degrees) suggested by Malvern Panalytical
+        # nominal_divergence = 0.005
+        self.source_divergence = 0.005
         self.slit1.distance = -entry['incidentRadius']
-        self.slit1.x = entry['sourceLineWidth']
+        self.slit1.x = FULLY_OPEN_SLIT
         self.slit2.distance = -entry['divergenceSlitDistance']
         self.slit2.x = entry['divergenceSlitHeight']
         self.slit3.distance = entry['diffractedRadius']

--- a/reflred/xrdml.py
+++ b/reflred/xrdml.py
@@ -32,6 +32,7 @@ def parse_measurement_node(node, ns, context):
     # output['wavelength'] = (ka1 + kratio * ka2) / (kratio + 1.0)
 
     context['incidentRadius'] = float(node.find("./incidentBeamPath/radius", ns).text)
+    context['incidentMirrorPresent'] = node.find("./incidentBeamPath/xRayMirror", ns) is not None
     context['sourceLineWidth'] = float(node.find("./incidentBeamPath/xRayTube/focus/width", ns).text)
 
     divergence_slit = node.find("./incidentBeamPath/divergenceSlit", ns)
@@ -41,9 +42,9 @@ def parse_measurement_node(node, ns, context):
 
     context['diffractedRadius'] = float(node.find("./diffractedBeamPath/radius", ns).text)
     
-    detector = node.find("./diffractedBeamPath/detector", ns)
-    detectorTypeKey = next(k for k in detector.attrib if k.endswith('type'))
-    detectorType = detector.attrib[detectorTypeKey]
+    # detector = node.find("./diffractedBeamPath/detector", ns)
+    # detectorTypeKey = next(k for k in detector.attrib if k.endswith('type'))
+    # detectorType = detector.attrib[detectorTypeKey]
     
     receivingSlitHeight = None
     receiving_slit = node.find("./diffractedBeamPath/receivingSlit", ns)


### PR DESCRIPTION
Add an attribute 'source_divergence' to ReflData class, defining the max divergence (full-width) of the source.  It should be used in circumstances where there are optics in place that create this limit, e.g. parabolic mirrors on X-ray sources.  For neutron sources where slit1 and slit2 define the beam, it should be left as None.

It is then used in the calculation of 
 - divergence (angular_resolution is set to the lesser of source_divergence and the computed divergence from the slits)
 - footprint