### PR TITLE
Add instructions to install server

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -52,7 +52,7 @@ Then start the server with::
 
 For the very latest development version use the following::
 
-    pip install "git+https://github.com/reductus/reductus.git#egg=reductus[server]"
+    pip install "git+https://github.com/reductus/reductus.git#egg=reductus[all]"
 
 Method 2: Docker Compose
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -39,17 +39,20 @@ with the local datastore enabled in config)
 Installation and use
 --------------------
 
-Method 1: pypi install
+Method 1: pip install
 ~~~~~~~~~~~~~~~~~~~~~~
 
 ::
 
-    pip install reductus
+    pip install "reductus[all]"
 
 Then start the server with::
 
     reductus
 
+For the very latest development version use the following::
+
+    pip install "git+https://github.com/reductus/reductus.git#egg=reductus[server]"
 
 Method 2: Docker Compose
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,19 @@ if os.system('"{sys.executable}" dataflow/rev.py'.format(sys=sys)) != 0:
 
 packages = find_packages(exclude=['reflbin'])
 
+# PIP dependencies
+install_requires = [
+    'scipy', 'numpy', 'uncertainties', 'docutils',
+    'pytz', 'importlib_resources'
+    ]
+extras_require = {
+    'server': ['msgpack', 'flask', 'flask-cors', 'requests'],
+    'masked_curve_fit': ['numdifftools'],
+    'nexus_files': ['h5py']
+    }
+extras_require['all'] = sum(extras_require.values(), [])
+tests_require = ['pytest']
+
 #sys.dont_write_bytecode = False
 dist = setup(
     name='reductus',
@@ -50,12 +63,9 @@ dist = setup(
         'scipy', 'numpy', 'uncertainties', 'docutils',
         'pytz', 'importlib_resources'
         ],
-    extras_require={
-        'server': ['msgpack', 'flask', 'flask-cors', 'requests'],
-        'masked_curve_fit': ['numdifftools'],
-        'nexus_files': ['h5py']
-        },
-    tests_require=['pytest'],
+    install_requires=install_requires,
+    extras_require=extras_require,
+    tests_require=test_require,
     )
 
 # End of file

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ if os.system('"{sys.executable}" dataflow/rev.py'.format(sys=sys)) != 0:
 
 packages = find_packages(exclude=['reflbin'])
 
-# PIP dependencies
+# pip dependencies
 install_requires = [
     'scipy', 'numpy', 'uncertainties', 'docutils',
     'pytz', 'importlib_resources'
@@ -59,13 +59,9 @@ dist = setup(
     entry_points = {
         'console_scripts': ['reductus=web_gui.run:main'],
     },
-    install_requires=[
-        'scipy', 'numpy', 'uncertainties', 'docutils',
-        'pytz', 'importlib_resources'
-        ],
     install_requires=install_requires,
     extras_require=extras_require,
-    tests_require=test_require,
+    tests_require=tests_require,
     )
 
 # End of file


### PR DESCRIPTION
"pip install" doesn't include the server dependencies by default. This patch updates the instructions so that the server will be included. Added the [all] option to pull in all dependencies.

I'd rather that we had the server by default with a "no-server" option to remove the flask dependency but I don't think we can do that.