### PR TITLE
Simplified API for loading instruments by URL

### DIFF
--- a/reductus/configurations/default.py
+++ b/reductus/configurations/default.py
@@ -54,4 +54,5 @@ config = {
     # if not set, will instantiate all instruments.
     "instruments": ["refl", "ospec", "sans", "vsans", "gans"],
     "show_exceptions": True,
+    "instrument_prefix": "ncnr",
 }

--- a/reductus/configurations/default_config.json
+++ b/reductus/configurations/default_config.json
@@ -23,5 +23,6 @@
         }
     ],
     "instruments": ["refl", "ospec", "sans"],
-    "show_exceptions": true
+    "show_exceptions": true,
+    "instrument_prefix": "ncnr"
 }

--- a/reductus/web_gui/server_flask.py
+++ b/reductus/web_gui/server_flask.py
@@ -50,6 +50,23 @@ def create_app(config=None):
             return redirect(posixpath.join(STATIC_FOLDER, DIST_PATH, CLIENT))
         else:
             return redirect(posixpath.join(STATIC_FOLDER, CLIENT))
+        
+    @app.route('/<instrument>')
+    def use_instrument(instrument):
+        # A simplified interface to load a specific instrument
+        # This uses the existing GET structure, but is a bit less strict on the name
+        known_instruments = api.list_instruments()
+        # Explicitly coerce the instrument name to a lower-case string
+        instrument = str(instrument).lower()
+        # Get base URL
+        initial_redirect = root()
+        if instrument not in known_instruments:
+            # Allow for { vsans | sans | refl } instead of ncnr.{ vsans | sans | refl }
+            instrument = f"ncnr.{instrument}"
+        if instrument in known_instruments:
+            # If the name passed matches a known instrument, set the redirect location to include the instrument
+            initial_redirect.location = f"{redir.location}?instrument={instrument}"
+        return initial_redirect
 
     @app.route('/robots.txt')
     def static_from_root():

--- a/reductus/web_gui/server_flask.py
+++ b/reductus/web_gui/server_flask.py
@@ -60,12 +60,13 @@ def create_app(config=None):
         instrument = str(instrument).lower()
         # Get base URL
         initial_redirect = root()
-        if instrument not in known_instruments:
-            # Allow for { vsans | sans | refl } instead of ncnr.{ vsans | sans | refl }
-            instrument = f"ncnr.{instrument}"
+        if instrument not in known_instruments and config.get('instrument_prefix', None):
+            # Allow passed instrument name to be { vsans | sans | refl } instead of ncnr.{ vsans | sans | refl }
+            instrument = f"{config.get('instrument_prefix')}.{instrument}"
         if instrument in known_instruments:
             # If the name passed matches a known instrument, set the redirect location to include the instrument
             initial_redirect.location = f"{redir.location}?instrument={instrument}"
+            initial_redirect.location = f"{initial_redirect.location}?instrument={instrument}"
         return initial_redirect
 
     @app.route('/robots.txt')

--- a/reductus/web_gui/server_flask.py
+++ b/reductus/web_gui/server_flask.py
@@ -63,10 +63,8 @@ def create_app(config=None):
         if instrument not in known_instruments and config.get('instrument_prefix', None):
             # Allow passed instrument name to be { vsans | sans | refl } instead of ncnr.{ vsans | sans | refl }
             instrument = f"{config.get('instrument_prefix')}.{instrument}"
-        if instrument in known_instruments:
-            # If the name passed matches a known instrument, set the redirect location to include the instrument
-            initial_redirect.location = f"{redir.location}?instrument={instrument}"
-            initial_redirect.location = f"{initial_redirect.location}?instrument={instrument}"
+        # Regardless of the resulting instrument name, attempt to load the instrument and let the client manage
+        initial_redirect.location = f"{initial_redirect.location}?instrument={instrument}"
         return initial_redirect
 
     @app.route('/robots.txt')

--- a/reductus/web_gui/webreduce/js/editor.js
+++ b/reductus/web_gui/webreduce/js/editor.js
@@ -690,7 +690,15 @@ editor.switch_instrument = async function(instrument_id, load_default=true) {
   // load_default_template is a boolean: true if you want to do that action
   // (defaults to true)
   if (instrument_id !== editor._instrument_id) {
-    let instrument_def = await this.load_instrument(instrument_id);
+    let original_id = editor._instrument_id;
+    let instrument_def = Object;
+    try {
+      instrument_def = await this.load_instrument(instrument_id);
+    }
+    catch (error) {
+      alert("Unable to load instrument " + instrument_id + ". Loading the default instrument instead.")
+      instrument_def = await this.load_instrument(original_id);
+    }
     let categories = editor.instruments[instrument_id].categories;
     let old_categories = vueMenu.instance.categories;
     old_categories.splice(0, old_categories.length, ...categories);


### PR DESCRIPTION
This creates a simplified Flask route for loading a specific instrument by URL. This also adds a default value for the facility name (ncnr in the base case) to give more flexibility to the value passed to the URL, such that `ncnr` is not required. 

Examples (with 'ncnr' set as the default):
- `localhost/vsans/` redirects to `localhost/webreduce/index.html?instrument=ncnr.vsans`
- `localhost/VSANS/` redirects to `localhost/webreduce/index.html?instrument=ncnr.vsans`
- `localhost/ncnr.sans/` redirects to `localhost/webreduce/index.html?instrument=ncnr.sans`
- `localhost/nothing/` and anything other value that is not in the instrument gives an alert that the url cannot load and the default instrument is rendered
