### PR TITLE
Update ncnr.sans default

### DIFF
--- a/reductus/sansred/steps.py
+++ b/reductus/sansred/steps.py
@@ -1522,13 +1522,13 @@ def absolute_scaling(empty, sample, Tsam, div, instrument="NG7", integration_box
 
     **Inputs**
 
-    empty (sans2d): measurement with no sample in the beam
-
     sample (sans2d): measurement with sample in the beam
+
+    div (sans2d): DIV measurement
 
     Tsam (params): sample transmission
 
-    div (sans2d): DIV measurement
+    empty (sans2d): measurement with no sample in the beam
 
     instrument (opt:NG7|NGB|NGB30): instrument name, should be NG7 or NG3
 
@@ -1548,6 +1548,7 @@ def absolute_scaling(empty, sample, Tsam, div, instrument="NG7", integration_box
     | 2017-01-13 Andrew Jackson
     | 2019-07-04 Brian Maranville
     | 2019-07-14 Brian Maranville
+    | 2025-07-17 Jeff Krzywon
     """
         # data (that is going through reduction), empty beam,
     # div, Transmission of the sample, instrument(NG3.NG5, NG7)

--- a/reductus/sansred/templates/ncnr.sans.default.json
+++ b/reductus/sansred/templates/ncnr.sans.default.json
@@ -11,8 +11,7 @@
         "do_deadtime": true
       },
       "y": 5,
-      "title": "sample",
-      "text_width": 64
+      "title": "sample"
     },
     {
       "x": 10,
@@ -24,8 +23,7 @@
         "do_det_eff": true
       },
       "y": 65,
-      "title": "empty cell",
-      "text_width": 85
+      "title": "empty cell"
     },
     {
       "x": 10,
@@ -37,8 +35,7 @@
         "do_det_eff": true
       },
       "y": 155,
-      "title": "empty trans",
-      "text_width": 96
+      "title": "empty trans"
     },
     {
       "x": 10,
@@ -50,8 +47,7 @@
         "do_det_eff": true
       },
       "y": 125,
-      "title": "sample trans",
-      "text_width": 104
+      "title": "sample trans"
     },
     {
       "x": 200,
@@ -66,8 +62,7 @@
           57.86973180076629,
           72
         ]
-      },
-      "text_width": 80
+      }
     },
     {
       "x": 10,
@@ -79,36 +74,31 @@
         "do_det_eff": true
       },
       "y": 35,
-      "title": "blocked",
-      "text_width": 67
+      "title": "blocked"
     },
     {
       "x": 200,
       "module": "ncnr.sans.subtract",
       "y": 5,
-      "title": "Subtract",
-      "text_width": 71
+      "title": "Subtract"
     },
     {
       "x": 200,
       "module": "ncnr.sans.subtract",
       "y": 65,
-      "title": "Subtract",
-      "text_width": 71
+      "title": "Subtract"
     },
     {
       "x": 365,
       "module": "ncnr.sans.product",
       "y": 35,
-      "title": "Product",
-      "text_width": 67
+      "title": "Product"
     },
     {
       "x": 525,
       "module": "ncnr.sans.subtract",
       "y": 5,
-      "title": "Subtract",
-      "text_width": 71
+      "title": "Subtract"
     },
     {
       "x": 895,
@@ -123,8 +113,7 @@
           56,
           73
         ]
-      },
-      "text_width": 83
+      }
     },
     {
       "module": "ncnr.sans.LoadDIV",
@@ -142,8 +131,7 @@
             ]
           }
         ]
-      },
-      "text_width": 36
+      }
     },
     {
       "module": "ncnr.sans.PixelsToQ",
@@ -152,8 +140,7 @@
       "y": 35,
       "config": {
         "correct_solid_angle": true
-      },
-      "text_width": 77
+      }
     },
     {
       "module": "ncnr.sans.circular_av_new",
@@ -163,15 +150,13 @@
       "config": {
         "dQ_method": "IGOR",
         "mask_width": 3
-      },
-      "text_width": 125
+      }
     },
     {
       "module": "ncnr.sans.correct_detector_sensitivity",
       "title": "Div Correction",
       "x": 685,
-      "y": 5,
-      "text_width": 113
+      "y": 5
     },
     {
       "module": "ncnr.sans.SuperLoadSANS",
@@ -181,8 +166,7 @@
       "config": {
         "filelist": [],
         "do_mon_norm": false
-      },
-      "text_width": 132
+      }
     },
     {
       "x": 685,
@@ -197,8 +181,7 @@
           57.86973180076629,
           72
         ]
-      },
-      "text_width": 80
+      }
     }
   ],
   "wires": [

--- a/reductus/sansred/templates/ncnr.sans.default.json
+++ b/reductus/sansred/templates/ncnr.sans.default.json
@@ -11,7 +11,8 @@
         "do_deadtime": true
       },
       "y": 5,
-      "title": "sample"
+      "title": "sample",
+      "text_width": 64
     },
     {
       "x": 10,
@@ -23,7 +24,8 @@
         "do_det_eff": true
       },
       "y": 65,
-      "title": "empty cell"
+      "title": "empty cell",
+      "text_width": 85
     },
     {
       "x": 10,
@@ -34,11 +36,12 @@
         "do_mon_norm": false,
         "do_det_eff": true
       },
-      "y": 140,
-      "title": "open trans"
+      "y": 155,
+      "title": "empty trans",
+      "text_width": 96
     },
     {
-      "x": 5,
+      "x": 10,
       "module": "ncnr.sans.SuperLoadSANS",
       "config": {
         "filelist": [],
@@ -46,13 +49,14 @@
         "do_atten_correct": true,
         "do_det_eff": true
       },
-      "y": 110,
-      "title": "sample trans"
+      "y": 125,
+      "title": "sample trans",
+      "text_width": 104
     },
     {
-      "x": 255,
+      "x": 200,
       "module": "ncnr.sans.generate_transmission",
-      "y": 110,
+      "y": 155,
       "title": "Gen trans",
       "config": {
         "align_by": "",
@@ -62,7 +66,8 @@
           57.86973180076629,
           72
         ]
-      }
+      },
+      "text_width": 80
     },
     {
       "x": 10,
@@ -74,36 +79,41 @@
         "do_det_eff": true
       },
       "y": 35,
-      "title": "blocked"
+      "title": "blocked",
+      "text_width": 67
     },
     {
       "x": 200,
       "module": "ncnr.sans.subtract",
       "y": 5,
-      "title": "Subtract"
+      "title": "Subtract",
+      "text_width": 71
     },
     {
-      "x": 230,
+      "x": 200,
       "module": "ncnr.sans.subtract",
-      "y": 55,
-      "title": "Subtract"
+      "y": 65,
+      "title": "Subtract",
+      "text_width": 71
     },
     {
-      "x": 380,
+      "x": 365,
       "module": "ncnr.sans.product",
-      "y": 30,
-      "title": "Product"
+      "y": 35,
+      "title": "Product",
+      "text_width": 67
     },
     {
-      "x": 515,
+      "x": 525,
       "module": "ncnr.sans.subtract",
       "y": 5,
-      "title": "Subtract"
+      "title": "Subtract",
+      "text_width": 71
     },
     {
-      "x": 935,
+      "x": 895,
       "module": "ncnr.sans.absolute_scaling",
-      "y": 50,
+      "y": 35,
       "title": "Abs Scale",
       "config": {
         "auto_box": false,
@@ -113,13 +123,14 @@
           56,
           73
         ]
-      }
+      },
+      "text_width": 83
     },
     {
       "module": "ncnr.sans.LoadDIV",
       "title": "DIV",
-      "x": 590,
-      "y": 140,
+      "x": 525,
+      "y": 65,
       "config": {
         "filelist": [
           {
@@ -131,42 +142,63 @@
             ]
           }
         ]
-      }
+      },
+      "text_width": 36
     },
     {
       "module": "ncnr.sans.PixelsToQ",
       "title": "Pixelstoq",
-      "x": 1085,
-      "y": 50,
+      "x": 1045,
+      "y": 35,
       "config": {
         "correct_solid_angle": true
-      }
+      },
+      "text_width": 77
     },
     {
       "module": "ncnr.sans.circular_av_new",
       "title": "Circular Av New",
-      "x": 1230,
-      "y": 50,
+      "x": 1190,
+      "y": 35,
       "config": {
         "dQ_method": "IGOR",
         "mask_width": 3
-      }
+      },
+      "text_width": 125
     },
     {
       "module": "ncnr.sans.correct_detector_sensitivity",
       "title": "Div Correction",
-      "x": 725,
-      "y": 5
+      "x": 685,
+      "y": 5,
+      "text_width": 113
     },
     {
       "module": "ncnr.sans.SuperLoadSANS",
-      "title": "empty trans",
-      "x": 755,
-      "y": 50,
+      "title": "open beam trans",
+      "x": 480,
+      "y": 155,
       "config": {
         "filelist": [],
         "do_mon_norm": false
-      }
+      },
+      "text_width": 132
+    },
+    {
+      "x": 685,
+      "module": "ncnr.sans.generate_transmission",
+      "y": 95,
+      "title": "Gen trans",
+      "config": {
+        "align_by": "",
+        "integration_box": [
+          58.05363984674328,
+          74,
+          57.86973180076629,
+          72
+        ]
+      },
+      "text_width": 80
     }
   ],
   "wires": [
@@ -282,16 +314,6 @@
     },
     {
       "source": [
-        4,
-        "output"
-      ],
-      "target": [
-        10,
-        "Tsam"
-      ]
-    },
-    {
-      "source": [
         10,
         "abs"
       ],
@@ -348,6 +370,36 @@
       "target": [
         10,
         "empty"
+      ]
+    },
+    {
+      "source": [
+        16,
+        "output"
+      ],
+      "target": [
+        10,
+        "Tsam"
+      ]
+    },
+    {
+      "source": [
+        3,
+        "output"
+      ],
+      "target": [
+        16,
+        "in_beam"
+      ]
+    },
+    {
+      "source": [
+        15,
+        "output"
+      ],
+      "target": [
+        16,
+        "empty_beam"
       ]
     }
   ]


### PR DESCRIPTION
This updated the default SANS reduction flow to correct for incorrect transmission usage (open vs. empty), updates the inputs for the abs calculator (and the date of change), and tidies up the look of the flow.

Fixes #165
Fixes #168